### PR TITLE
Allow installation from source-requirements.yml

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -9,6 +9,7 @@ cnamespace
 cpart
 cpath
 crepository
+csource
 fileh
 fqcn
 levelname

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -99,6 +99,14 @@ def parse() -> argparse.Namespace:
     )
 
     level1.add_argument(
+        "--cpi",
+        "--collection-pre-install",
+        help="Pre install collections from source, reads source-requirements.yml file.",
+        default=False,
+        action="store_true",
+    )
+
+    level1.add_argument(
         "--na",
         "--no-ansi",
         action="store_true",

--- a/src/ansible_dev_environment/cli.py
+++ b/src/ansible_dev_environment/cli.py
@@ -36,6 +36,10 @@ class Cli:
         self.args = parse()
         if hasattr(self.args, "requirement") and self.args.requirement:
             self.args.requirement = Path(self.args.requirement).expanduser().resolve()
+        if self.args.cpi:
+            self.args.requirement = (
+                Path(".config/source-requirements.yml").expanduser().resolve()
+            )
 
     def init_output(self: Cli) -> None:
         """Initialize the output object."""

--- a/src/ansible_dev_environment/collection.py
+++ b/src/ansible_dev_environment/collection.py
@@ -26,6 +26,7 @@ class Collection:  # pylint: disable=too-many-instance-attributes
     local: bool | None = None
     cnamespace: str | None = None
     cname: str | None = None
+    csource: list[str] | None = None
     specifier: str | None = None
     original: str | None = None
 


### PR DESCRIPTION
Enable source installation capabilities, it depends on the `.config/source-requirements.yml` file to pick up dependencies to source install them.

Command example - 
```shell
ade install ".[test]" --venv venv --cpi
```

Attribute added - 
`cpi/ collection-pre-install`

Example _source-requirements.yml_
```yaml
---
collections:
  - git+https://github.com/ansible-collections/ansible.utils.git
  - git+https://github.com/ansible-collections/ansible.netcommon.git
```

Log -
```
ansible_development_environment install .\[test\] --venv venv --cpi
    Note: Source installed collections include: ansible.netcommon and ansible.utils
    Note: Installed collections include: ansible.netcommon, ansible.utils, and cisco.ios
    Note: All python requirements are installed.
    Note: All required system packages are installed.
    Note: A virtual environment was specified but has not been activated.
    Note: Please activate the virtual environment:
          source venv/bin/activate
```
Force installing collections from source, automatically make ansible-galaxy skip installing dependencies.


Fixes: #79