### PR TITLE
Fix installation of local collection in editable mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
         name: Spell check with cspell
 
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.3.10
+    rev: 0.4.0
     hooks:
       - id: pydoclint
         args:


### PR DESCRIPTION
The PR:
1. Splits chained `git ls-files` and `ls` commands and executes them separately to copy files from the local directory to the collection build directory (Fixes: #127).
2. Updates `pydoclint` to v0.4.0 in the pre commit config.