### PR TITLE
Add system site package flag

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -15,6 +15,7 @@ fqcn
 levelname
 levelno
 netcommon
+purelib
 reqs
 setenv
 specp

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -115,6 +115,15 @@ def parse() -> argparse.Namespace:
         help="Disable the use of ANSI codes for terminal hyperlink generation and color.",
     )
 
+    level1.add_argument(
+        "--ssp",
+        "--system-site-packages",
+        help="When building a virtual environment, give access to the system site-packages dir.",
+        default=False,
+        dest="system_site_packages",
+        action="store_true",
+    )
+
     common_args(level1)
 
     _check = subparsers.add_parser(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,61 @@
+"""Test the config module."""
+
+from __future__ import annotations
+
+import argparse
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ansible_dev_environment.config import Config
+from ansible_dev_environment.output import Output
+from ansible_dev_environment.utils import TermFeatures
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    "system_site_packages",
+    ((True, False)),
+    ids=["ssp_true", "ssp_false"],
+)
+def test_paths(tmpdir: Path, system_site_packages: bool) -> None:  # noqa: FBT001
+    """Test the paths.
+
+    Several of the found directories should have a parent of the tmpdir / test_venv
+
+    Args:
+        tmpdir: A temporary directory.
+        system_site_packages: Whether to include system site packages.
+    """
+    venv = tmpdir / "test_venv"
+    args = argparse.Namespace(
+        venv=str(venv),
+        system_site_packages=system_site_packages,
+        verbose=0,
+    )
+    term_features = TermFeatures(color=False, links=False)
+
+    output = Output(
+        log_file=str(tmpdir / "test_log.log"),
+        log_level="debug",
+        log_append="false",
+        term_features=term_features,
+        verbosity=0,
+    )
+
+    config = Config(args=args, output=output, term_features=term_features)
+    config.init()
+
+    assert config.venv == venv
+    for attr in (
+        "site_pkg_collections_path",
+        "site_pkg_path",
+        "venv_bindir",
+        "venv_cache_dir",
+        "venv_interpreter",
+    ):
+        assert venv in getattr(config, attr).parents


### PR DESCRIPTION
For RPMs or cases where ADT has already been installed, allow for site packages in the venv

- Add the ability to use the system site package flag for the venv
- Switch from getsitepackages to sysconfig for better identification of the interpreters local siste packages directory
- Add tests
Closes #138 
Closes #139 