### PR TITLE
Add ansible-dev-tools install into venv `--ansible-dev-tools`

### DIFF
--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -181,6 +181,14 @@ def parse() -> argparse.Namespace:
         help="Install editable.",
     )
 
+    install.add_argument(
+        "-adt",
+        "--ansible-dev-tools",
+        action="store_true",
+        dest="adt",
+        help="Install ansible-dev-tools in the virtual environment.",
+    )
+
     _uninstall = subparsers.add_parser(
         "uninstall",
         formatter_class=CustomHelpFormatter,

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -51,7 +51,11 @@ class Installer:
             err = "Multiple optional dependencies are not supported at this time."
             self._output.critical(err)
 
-        self._install_core()
+        if self._config.args.adt:
+            self._install_dev_tools()
+        else:
+            self._install_core()
+
         if self._config.args.requirement or self._config.args.cpi:
             self._install_galaxy_requirements()
         if self._config.args.collection_specifier:
@@ -114,6 +118,28 @@ class Installer:
             )
         except subprocess.CalledProcessError as exc:
             err = f"Failed to install ansible-core: {exc}"
+            self._output.critical(err)
+
+    def _install_dev_tools(self: Installer) -> None:
+        """Install ansible developer tools."""
+        msg = "Installing ansible-dev-tools."
+        self._output.info(msg)
+
+        adt = self._config.venv_bindir / "adt"
+        if adt.exists():
+            return
+        msg = "Installing ansible-dev-tools."
+        self._output.debug(msg)
+        command = f"{self._config.venv_interpreter} -m pip install ansible-dev-tools"
+        try:
+            subprocess_run(
+                command=command,
+                verbose=self._config.args.verbose,
+                msg=msg,
+                output=self._output,
+            )
+        except subprocess.CalledProcessError as exc:
+            err = f"Failed to install ansible-dev-tools: {exc}"
             self._output.critical(err)
 
     def _install_galaxy_collections(

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -155,3 +155,65 @@ def test_copy_using_ls(tmp_path: Path, output: Output) -> None:
     installer._copy_repo_files(local_repo_path=source, destination_path=dest)
     moved = dest.glob("**/*")
     assert sorted([m.name for m in list(moved)]) == ["file1.txt", "file2.txt"]
+
+
+def test_no_adt_install(
+    tmpdir: Path,
+    output: Output,
+) -> None:
+    """Test only core is installed.
+
+    Args:
+        tmpdir: A temporary directory.
+        output: The output fixture.
+    """
+    venv = tmpdir / "test_venv"
+    args = Namespace(
+        venv=venv,
+        verbose=0,
+        adt=False,
+        system_site_packages=False,
+        collection_specifier=None,
+        requirement=None,
+        cpi=None,
+    )
+
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+
+    installer = Installer(output=output, config=config)
+    installer.run()
+    assert venv.exists()
+    assert (venv / "bin" / "ansible").exists()
+    assert not (venv / "bin" / "adt").exists()
+
+
+def test_adt_install(
+    tmpdir: Path,
+    output: Output,
+) -> None:
+    """Test adt is installed.
+
+    Args:
+        tmpdir: A temporary directory.
+        output: The output fixture.
+    """
+    venv = tmpdir / "test_venv"
+    args = Namespace(
+        venv=venv,
+        verbose=0,
+        adt=True,
+        system_site_packages=False,
+        collection_specifier=None,
+        requirement=None,
+        cpi=None,
+    )
+
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+
+    installer = Installer(output=output, config=config)
+    installer.run()
+    assert venv.exists()
+    assert (venv / "bin" / "ansible").exists()
+    assert (venv / "bin" / "adt").exists()


### PR DESCRIPTION
Having ansible-dev-tools installed in the virtual environment removes one step the user needs to take when setting up a development environment for a playbook collection

This results in a totally isolated development environment for the project in one command.

Tests included

Closes #109 