### PR TITLE
Enable pydoclint via flake 8

### DIFF
--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -1,9 +1,10 @@
 black
 coverage[toml]
+flake8
 mypy
 pip-tools
 pre-commit
-pydoclint
+pydoclint[flake8]
 pytest
 pytest-xdist
 ruff

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+allow-init-docstring = True
+arg-type-hints-in-docstring = False
+check-return-types = False
+select = DOC
+show-filenames-in-every-violation-message = True
+skip-checking-short-docstrings = False
+filename =
+    */src/**/*.py
+    */tests/**/*.py
+style = google

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,12 +70,13 @@ repos:
       - id: cspell
         name: Spell check with cspell
 
-  - repo: https://github.com/jsh9/pydoclint
-    rev: 0.4.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
     hooks:
-      - id: pydoclint
-        args:
-          - "--config=pyproject.toml"
+      - id: flake8
+        name: flake8(pydoclint)
+        additional_dependencies:
+          - pydoclint
 
   - repo: https://github.com/pycqa/pylint.git
     rev: v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: flake8
         name: flake8(pydoclint)
         additional_dependencies:
-          - pydoclint
+          - pydoclint[flake8]
 
   - repo: https://github.com/pycqa/pylint.git
     rev: v3.1.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "markis.code-coverage",
     "ms-python.black-formatter",
     "ms-python.debugpy",
+    "ms-python.flake8",
     "ms-python.mypy-type-checker",
     "ms-python.pylint",
     "ms-python.python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.formatOnSave": true
   },
+  "flake8.importStrategy": "fromEnvironment",
   "markiscodecoverage.searchCriteria": "coverage.lcov",
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "mypy-type-checker.preferDaemon": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,7 +332,7 @@ lines-between-types = 1 # Separate import/from with 1 line
 "_version.py" = ["SIM108"]
 
 [tool.ruff.lint.pydocstyle]
-convention = "pep257"
+convention = "google"
 
 [tool.setuptools.dynamic]
 dependencies = {file = [".config/requirements.in"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,6 @@ concurrency = ["multiprocessing", "thread"]
 files = ["src", "tests"]
 strict = true
 
-[tool.pydoclint]
-allow-init-docstring = true
-arg-type-hints-in-docstring = false
-check-return-types = false
-show-filenames-in-every-violation-message = true
-skip-checking-short-docstrings = false
-style = 'google'
-
 [tool.pylint]
 
 [tool.pylint.format]

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -253,6 +253,7 @@ class Installer:
 
         Args:
             local_repo_path: The collection local path.
+
         Returns:
             string with the command used to list files or None
             string containing a list of files or nothing
@@ -284,6 +285,7 @@ class Installer:
 
         Args:
             local_repo_path: The collection local path.
+
         Returns:
             string with the command used to list files or None
             string containing a list of files or nothing

--- a/src/ansible_dev_environment/subcommands/treemaker.py
+++ b/src/ansible_dev_environment/subcommands/treemaker.py
@@ -24,6 +24,7 @@ class TreeMaker:
 
         Args:
             config: The application configuration.
+            output: The application output object.
         """
         self._config = config
         self._output = output

--- a/src/ansible_dev_environment/subcommands/treemaker.py
+++ b/src/ansible_dev_environment/subcommands/treemaker.py
@@ -24,7 +24,6 @@ class TreeMaker:
 
         Args:
             config: The application configuration.
-            output: The application output object.
         """
         self._config = config
         self._output = output

--- a/src/ansible_dev_environment/utils.py
+++ b/src/ansible_dev_environment/utils.py
@@ -338,6 +338,7 @@ def collections_meta(config: Config) -> dict[str, dict[str, Any]]:
 
     Args:
         config: The configuration object.
+
     Returns:
         A dictionary of metadata about installed collections.
     """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,6 +20,7 @@ def output(tmp_path: Path) -> Output:
 
     Args:
         tmp_path: Temporary directory.
+
     Returns:
         Output: Output class object.
     """


### PR DESCRIPTION
Unfortunately it appears the only way to get pydoclint feedback within VsCode is to use it as a flake8 plugin.

- Move the pydoclint config to .flake8
- Replace the pydoclint precommit config w/ flake8
- Add the falke8 extension and cofiguration
- This is only untill ruff has full doc string support

Additionally, ruff`s docstyle was set to match pydoclint which fixed 4 little issues

(it also appears ruff may implement pydoclint instead of ruff, no decision yet https://github.com/astral-sh/ruff/issues/458#issuecomment-2122773827 so I think we're headed in a good direction)