### PR TITLE
Simplify the coverage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,4 @@ cython_debug/
 # Version created and populated by setuptools_scm
 /src/*/_version.py
 
-# Coverage files
-*.lcov
-
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     "editor.formatOnSave": true
   },
   "flake8.importStrategy": "fromEnvironment",
-  "markiscodecoverage.searchCriteria": "coverage.lcov",
+  "markiscodecoverage.searchCriteria": ".coverage/lcov.info",
   "mypy-type-checker.args": ["--config-file=${workspaceFolder}/pyproject.toml"],
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "mypy-type-checker.preferDaemon": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ homepage = "https://github.com/ansible/ansible-dev-environment"
 repository = "https://github.com/ansible/ansible-dev-environment"
 
 [tool.coverage.report]
+ignore_errors = true
 exclude_lines = ["if TYPE_CHECKING:", "pragma: no cover"]
 fail_under = 72
 show_missing = true

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ pass_env =
     USER
 set_env =
     COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
+    COVERAGE_COMBINED = {envdir}/.coverage
     COVERAGE_PROCESS_START = {toxinidir}/pyproject.toml
     FORCE_COLOR = 1
     PIP_CONSTRAINT = {toxinidir}/.config/constraints.txt
@@ -36,15 +37,11 @@ commands_pre =
 commands =
     python -c 'import pathlib; pathlib.Path("{env_site_packages_dir}/cov.pth").write_text("import coverage; coverage.process_startup()")'
     coverage run -m pytest {posargs:-n auto}
-    {py,py310,py311,py312,py313}: sh -c " \
-      coverage combine -q --data-file={envdir}/.coverage {envdir}/.coverage.* && \
-      coverage xml --data-file={envdir}/.coverage -o {envdir}/coverage.xml --ignore-errors --fail-under=0 && \
-      COVERAGE_FILE={envdir}/.coverage coverage lcov --fail-under=0 --ignore-errors -q && \
-      COVERAGE_FILE={envdir}/.coverage coverage report --ignore-errors \
-      "
+    coverage combine -q --data-file={env:COVERAGE_COMBINED}
+    coverage xml --data-file={env:COVERAGE_COMBINED} -o {envdir}/coverage.xml --fail-under=0
+    coverage lcov --data-file={env:COVERAGE_COMBINED} -o {toxinidir}/.coverage/lcov.info --fail-under=0
+    coverage report --data-file={env:COVERAGE_COMBINED}
 allowlist_externals =
-    git
-    rm
     sh
 
 [testenv:lint]
@@ -65,9 +62,7 @@ deps =
 set_env =
 commands =
     rm -rfv {toxinidir}/dist/
-    python -m build \
-      --outdir {toxinidir}/dist/ \
-      {toxinidir}
+    python -m build --outdir {toxinidir}/dist/ {toxinidir}
     sh -c "python -m twine check --strict {toxinidir}/dist/*"
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ commands =
     coverage lcov --data-file={env:COVERAGE_COMBINED} -o {toxinidir}/.coverage/lcov.info --fail-under=0
     coverage report --data-file={env:COVERAGE_COMBINED}
 allowlist_externals =
+    git
+    rm
     sh
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ pass_env =
     TERM
     USER
 set_env =
-    COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
     COVERAGE_COMBINED = {envdir}/.coverage
+    COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
     COVERAGE_PROCESS_START = {toxinidir}/pyproject.toml
     FORCE_COLOR = 1
     PIP_CONSTRAINT = {toxinidir}/.config/constraints.txt


### PR DESCRIPTION
- Move the lcov file into a dot directory to avoid a new gitignore as it is covered the the default GH python gitignore
- Use the seemingly more common name lcov.info
- Move ingore errors into pypreject.toml
- Set an ENVVAR for the combined file and ref it in the tox commands
- Remove env list for the coverage commands, all other sections have commands 
- Remove unecessary params from tox commands
- Remove uneeded `sh` and `&&` from commands
- Single line the build line