### PR TITLE
Simplify precommit mypy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,6 @@ repos:
         additional_dependencies:
           - pytest
           - subprocess_tee
-          - tox
           - types-PyYAML
           - types-setuptools
         # Override default pre-commit '--ignore-missing-imports'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,6 +101,8 @@ repos:
           - tox
           - types-PyYAML
           - types-setuptools
+        # Override default pre-commit '--ignore-missing-imports'
+        args: [--strict]
 
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,11 +101,7 @@ repos:
           - tox
           - types-PyYAML
           - types-setuptools
-        args:
-          - src
-          - tests
-          - --python-version=3.11
-        pass_filenames: false
+
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1
     hooks:


### PR DESCRIPTION
When running mypy with precommit, it uses the pyproject.toml file for config.

This removed config was not needed