### PR TITLE
Update default python to latest supported

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           min_python: "3.10"
           max_python: "3.12"
-          default_python: "3.11" # used by jobs in other_names
+          default_python: "3.12" # used by jobs in other_names
           other_names: |
             lint
             docs


### PR DESCRIPTION
Update default python to be 3.12 so it matches what pre-commit ci uses, so pylint results will be the same.