### PR TITLE
chore: Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     coverage run -m pytest {posargs:-n auto}
     coverage combine -q --data-file={env:COVERAGE_COMBINED}
     coverage xml --data-file={env:COVERAGE_COMBINED} -o {envdir}/coverage.xml --fail-under=0
-    coverage lcov --data-file={env:COVERAGE_COMBINED} -o {toxinidir}/.coverage/lcov.info --fail-under=0
+    coverage lcov --data-file={env:COVERAGE_COMBINED} -o {toxinidir}/.cache/.coverage/lcov.info --fail-under=0
     coverage report --data-file={env:COVERAGE_COMBINED}
 allowlist_externals =
     git


### PR DESCRIPTION
Move the coverage file into the .cache directory.
