### PR TITLE
Add tests

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -21,3 +21,4 @@ reqs
 setenv
 treemaker
 usefixtures
+xmltodict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ line-length = 100
 
 [tool.coverage.report]
 exclude_also = ["if TYPE_CHECKING:", "pragma: no cover"]
-fail_under = 72
+fail_under = 81
 ignore_errors = true
 show_missing = true
 skip_covered = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,4 +16,85 @@ Imported source package 'ansible_dev_environment' as '/**/src/<package>/__init__
 Tracing '/**/src/<package>/__init__.py'
 """
 
+import shutil
+import tempfile
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
 import ansible_dev_environment  # noqa: F401
+
+from ansible_dev_environment.cli import Cli
+from ansible_dev_environment.config import Config
+
+
+@pytest.fixture(name="monkey_session", scope="session")
+def fixture_monkey_session() -> Generator[pytest.MonkeyPatch, None, None]:
+    """Session scoped monkeypatch fixture.
+
+    Yields:
+        pytest.MonkeyPatch: The monkeypatch fixture.
+    """
+    monkey_patch = pytest.MonkeyPatch()
+    yield monkey_patch
+    monkey_patch.undo()
+
+
+@pytest.fixture(name="session_dir", scope="session")
+def fixture_session_dir() -> Generator[Path, None, None]:
+    """A session scoped temporary directory.
+
+    Yields:
+        Path: Temporary directory.
+    """
+    temp_dir = Path(tempfile.mkdtemp())
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture(scope="session")
+def session_venv(session_dir: Path, monkey_session: pytest.MonkeyPatch) -> Config:
+    """Create a temporary venv for the session.
+
+    Add some common collections to the venv.
+
+    Since this is a session level fixture, care should be taken to not manipulate it
+    or the resulting config in a way that would affect other tests.
+
+    Args:
+        session_dir: Temporary directory.
+        monkey_session: Pytest monkeypatch fixture.
+
+    Returns:
+        The configuration object for the venv.
+    """
+    venv_path = session_dir / "venv"
+    monkey_session.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "ansible.utils",
+            "ansible.scm",
+            "ansible.posix",
+            "--venv",
+            str(venv_path),
+            "--ll",
+            "debug",
+            "--la",
+            "true",
+            "--lf",
+            str(session_dir / "ade.log"),
+            "-vvv",
+        ],
+    )
+    cli = Cli()
+    cli.parse_args()
+    cli.init_output()
+    cli.args_sanity()
+    cli.ensure_isolated()
+    with pytest.raises(SystemExit):
+        cli.run()
+    return cli.config

--- a/tests/unit/test_collection.py
+++ b/tests/unit/test_collection.py
@@ -1,0 +1,131 @@
+"""Tests for the collection module."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ansible_dev_environment.collection import Collection, get_galaxy
+from ansible_dev_environment.config import Config
+from ansible_dev_environment.utils import TermFeatures
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ansible_dev_environment.output import Output
+
+
+@pytest.mark.usefixtures("_wide_console")
+def test_get_galaxy_missing(
+    tmp_path: Path,
+    output: Output,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test when the galaxy.yml file is missing.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output class object.
+        capsys: Pytest fixture
+    """
+    config = Config(
+        args=Namespace(),
+        term_features=TermFeatures(color=False, links=False),
+        output=output,
+    )
+    collection = Collection(
+        config=config,
+        path=tmp_path,
+        cname="utils",
+        cnamespace="ansible",
+        local=False,
+        original="ansible.utils",
+        specifier="",
+        opt_deps="",
+        csource=[],
+    )
+    with pytest.raises(SystemExit):
+        get_galaxy(collection, output)
+
+    captured = capsys.readouterr()
+    assert f"Failed to find {tmp_path / 'galaxy.yml'} in {tmp_path}\n" in captured.err
+
+
+@pytest.mark.usefixtures("_wide_console")
+def test_get_galaxy_no_meta(
+    tmp_path: Path,
+    output: Output,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test when the galaxy.yml file is name/namespace.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output class object.
+        capsys: Pytest fixture
+    """
+    (tmp_path / "galaxy.yml").write_text("corrupt: yaml\n")
+    config = Config(
+        args=Namespace(),
+        term_features=TermFeatures(color=False, links=False),
+        output=output,
+    )
+    collection = Collection(
+        config=config,
+        path=tmp_path,
+        cname="utils",
+        cnamespace="ansible",
+        local=False,
+        original="ansible.utils",
+        specifier="",
+        opt_deps="",
+        csource=[],
+    )
+    with pytest.raises(SystemExit):
+        get_galaxy(collection, output)
+
+    captured = capsys.readouterr()
+    assert (
+        f"Failed to find collection name in {tmp_path / 'galaxy.yml'}: 'namespace'\n"
+        in captured.err
+    )
+
+
+@pytest.mark.usefixtures("_wide_console")
+def test_get_galaxy_corrupt(
+    tmp_path: Path,
+    output: Output,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test when the galaxy.yml file is missing.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output class object.
+        capsys: Pytest fixture
+    """
+    (tmp_path / "galaxy.yml").write_text(",")
+    config = Config(
+        args=Namespace(),
+        term_features=TermFeatures(color=False, links=False),
+        output=output,
+    )
+    collection = Collection(
+        config=config,
+        path=tmp_path,
+        cname="utils",
+        cnamespace="ansible",
+        local=False,
+        original="ansible.utils",
+        specifier="",
+        opt_deps="",
+        csource=[],
+    )
+    with pytest.raises(SystemExit):
+        get_galaxy(collection, output)
+
+    captured = capsys.readouterr()
+    assert "Failed to load yaml file:" in captured.err

--- a/tests/unit/test_inspector.py
+++ b/tests/unit/test_inspector.py
@@ -1,0 +1,84 @@
+"""Tests for the inspector module."""
+
+import copy
+import importlib
+import json
+import re
+import sys
+
+import pytest
+
+from ansible_dev_environment.config import Config
+from ansible_dev_environment.subcommands import inspector
+
+
+def test_output_no_color(session_venv: Config, capsys: pytest.CaptureFixture) -> None:
+    """Test the inspector output.
+
+    Args:
+        session_venv: The configuration object for the venv.
+        capsys: Pytest capture fixture.
+    """
+    _inspector = inspector.Inspector(config=session_venv, output=session_venv._output)
+    _inspector.run()
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "ansible.posix" in data
+    assert "ansible.scm" in data
+    assert "ansible.utils" in data
+
+
+def test_output_color(
+    session_venv: Config,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the inspector output.
+
+    Args:
+        session_venv: The configuration object for the venv.
+        capsys: Pytest capture fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    config = copy.deepcopy(session_venv)
+    config.term_features.color = True
+    _inspector = inspector.Inspector(config=config, output=session_venv._output)
+    _inspector.run()
+    captured = capsys.readouterr()
+    assert captured.out.startswith("\x1b")
+    ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]")
+    no_ansi = ansi_escape.sub("", captured.out)
+    data = json.loads(no_ansi)
+    assert "ansible.posix" in data
+    assert "ansible.scm" in data
+    assert "ansible.utils" in data
+
+
+def test_no_rich(
+    session_venv: Config,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the inspector output when rich is not available.
+
+    Args:
+        session_venv: The configuration object for the venv.
+        capsys: Pytest capture fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    with monkeypatch.context() as monkey_rich:
+        monkey_rich.setitem(sys.modules, "pip._vendor.rich", None)
+        importlib.reload(inspector)
+        assert inspector.HAS_RICH is False
+
+        _inspector = inspector.Inspector(config=session_venv, output=session_venv._output)
+        _inspector.run()
+
+    importlib.reload(inspector)
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "ansible.posix" in data
+    assert "ansible.scm" in data
+    assert "ansible.utils" in data

--- a/tests/unit/test_inspector.py
+++ b/tests/unit/test_inspector.py
@@ -12,7 +12,7 @@ from ansible_dev_environment.config import Config
 from ansible_dev_environment.subcommands import inspector
 
 
-def test_output_no_color(session_venv: Config, capsys: pytest.CaptureFixture) -> None:
+def test_output_no_color(session_venv: Config, capsys: pytest.CaptureFixture[str]) -> None:
     """Test the inspector output.
 
     Args:
@@ -30,7 +30,7 @@ def test_output_no_color(session_venv: Config, capsys: pytest.CaptureFixture) ->
 
 def test_output_color(
     session_venv: Config,
-    capsys: pytest.CaptureFixture,
+    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test the inspector output.
@@ -57,7 +57,7 @@ def test_output_color(
 
 def test_no_rich(
     session_venv: Config,
-    capsys: pytest.CaptureFixture,
+    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test the inspector output when rich is not available.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -5,12 +5,14 @@ import runpy
 import pytest
 
 
-def test_main(capsys: pytest.CaptureFixture[str]) -> None:
+def test_main(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the main file.
 
     Args:
         capsys: Capture stdout and stderr
+        monkeypatch: Pytest monkeypatch fixture.
     """
+    monkeypatch.setattr("sys.argv", ["ansible-dev-environment"])
     with pytest.raises(SystemExit):
         runpy.run_module("ansible_dev_environment", run_name="__main__", alter_sys=True)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -41,6 +41,10 @@ scenarios = (
             cnamespace="ansible",
             local=False,
             original="ansible.utils",
+            specifier="",
+            path=Path(),
+            opt_deps="",
+            csource=[],
         ),
     ),
     (
@@ -52,6 +56,9 @@ scenarios = (
             specifier=":1.0.0",
             local=False,
             original="ansible.utils:1.0.0",
+            path=Path(),
+            opt_deps="",
+            csource=[],
         ),
     ),
     (
@@ -63,6 +70,9 @@ scenarios = (
             specifier=">=1.0.0",
             local=False,
             original="ansible.utils>=1.0.0",
+            path=Path(),
+            opt_deps="",
+            csource=[],
         ),
     ),
     (
@@ -73,8 +83,10 @@ scenarios = (
             config=config,
             local=True,
             path=FIXTURE_DIR,
-            specifier=None,
+            specifier="",
             original=str(FIXTURE_DIR),
+            opt_deps="",
+            csource=[],
         ),
     ),
     (
@@ -86,18 +98,15 @@ scenarios = (
             local=True,
             opt_deps="test",
             path=FIXTURE_DIR,
-            specifier=None,
+            specifier="",
             original=str(FIXTURE_DIR) + "/[test]",
+            csource=[],
         ),
     ),
-    (
-        "/foo/bar",
-        None,
-    ),
-    (
-        "abcdefg",
-        None,
-    ),
+    ("/foo/bar", None),
+    ("abcdefg", None),
+    ("/12345678901234567890[test]", None),
+    ("not_a_collection_name", None),
 )
 
 


### PR DESCRIPTION
- Add some additional tests
- Narrow the scope of the type used in treemaker to get rid of some isinstance checks
- Remove default values from `Collection` to remove some runtime value checks
- Remove some merge conflict info found in docstrings