### PR TITLE
Replace -adt/--ansible-dev-tools argument with --seed

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -87,6 +87,7 @@ pymdown-extensions==10.12
 pyproject-api==1.8.0
 pyproject-hooks==1.2.0
 pytest==8.3.4
+pytest-instafail==0.5.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
 python-slugify==8.0.4

--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -6,6 +6,7 @@ pre-commit
 pydoclint
 pylint
 pytest
+pytest-instafail
 pytest-xdist
 ruff
 toml-sort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,6 @@ repos:
           - prettier-plugin-toml
           - prettier-plugin-sort-json
 
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,6 +335,7 @@ target-version = "py310"
 [tool.ruff.lint]
 ignore = [
   "COM812", # conflicts with ISC001 on format
+  "E501", # line-too-long (ruff-format or black will take care of it)
   "ISC001" # conflicts with COM812 on format
 ]
 select = ["ALL"]

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import sys
 
 from argparse import HelpFormatter
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from typing import Any
@@ -186,11 +190,11 @@ def parse() -> argparse.Namespace:
     )
 
     install.add_argument(
-        "-adt",
-        "--ansible-dev-tools",
+        # "-adt",
+        "--seed",
         action="store_true",
         dest="adt",
-        help="Install ansible-dev-tools in the virtual environment.",
+        help="Install seed packages inside the virtual environment (ansible-dev-tools).",
     )
 
     _uninstall = subparsers.add_parser(
@@ -204,7 +208,14 @@ def parse() -> argparse.Namespace:
     for subparser in subparsers.choices.values():
         _group_titles(subparser)
 
-    return parser.parse_args()
+    args = sys.argv[1:]
+    for i, v in enumerate(args):
+        for old in ("-adt", "--ansible-dev-tools"):
+            if v == old:
+                msg = f"Replace the deprecated {old} argument with --seed to avoid future execution failure."
+                logger.warning(msg)
+                args[i] = "--seed"
+    return parser.parse_args(args)
 
 
 def _group_titles(parser: ArgumentParser) -> None:


### PR DESCRIPTION
From now on we will use `--seed` for installing extra packages when creating the venv. We still support the old argument names but they will be removed in the near future.

Related: https://issues.redhat.com/browse/AAP-30772