### PR TITLE
Make use of .venv environment implicit if none is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more information about communication, see the [Ansible communication guide](
 $ pip install ansible-dev-environment --user
 $ git clone <collection_repo>
 $ cd <collection_repo>
-$ ade install -e .\[test] --venv venv
+$ ade install -e .\[test] --venv .venv
 INFO: Found collection name: network.interfaces from /home/bthornto/github/network.interfaces/galaxy.yml.
 INFO: Creating virtual environment: /home/bthornto/github/network.interfaces/venv
 INFO: Virtual environment: /home/bthornto/github/network.interfaces/venv

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,13 +32,13 @@ By placing collections into the python site-packages directory they are discover
 {{ install_from_adt("ansible-dev-environment") }}
 
 ```bash
-pip install ansible-dev-environment --user
+pip3 install ansible-dev-environment --user
 ```
 
 ```
 $ git clone <collection_repo>
 $ cd <collection_repo>
-$ ade install -e .\[test] --venv venv
+$ ade install -e .\[test] --venv .venv
 INFO: Found collection name: network.interfaces from /home/bthornto/github/network.interfaces/galaxy.yml.
 INFO: Creating virtual environment: /home/bthornto/github/network.interfaces/venv
 INFO: Virtual environment: /home/bthornto/github/network.interfaces/venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ line-length = 100
 
 [tool.coverage.report]
 exclude_also = ["if TYPE_CHECKING:", "pragma: no cover"]
-fail_under = 81
+fail_under = 89
 ignore_errors = true
 show_missing = true
 skip_covered = true

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
+import warnings
 
 from argparse import HelpFormatter
 from pathlib import Path
@@ -99,10 +101,14 @@ def parse() -> argparse.Namespace:
 
     level1 = ArgumentParser(add_help=False)
 
+    venv_path = os.environ.get("VIRTUAL_ENV", None)
+    if not venv_path:
+        warnings.warn("No virtualenv found active, we will assume .venv", stacklevel=1)
     level1.add_argument(
         "--ve",
         "--venv <directory>",
         help="Target virtual environment.",
+        default=".venv",
         dest="venv",
     )
 


### PR DESCRIPTION
From now on, if a virtualenv is not already active, ade will assume the use of .venv environment for all commands and mention this in a warning message.

Related: https://issues.redhat.com/browse/AAP-30772