### PR TITLE
Remove ambiguous option --ve for providing the virtueanenv name

### DIFF
--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -105,7 +105,6 @@ def parse() -> argparse.Namespace:
     if not venv_path:
         warnings.warn("No virtualenv found active, we will assume .venv", stacklevel=1)
     level1.add_argument(
-        "--ve",
         "--venv <directory>",
         help="Target virtual environment.",
         default=".venv",


### PR DESCRIPTION
This is needed because we already have -v and -e options and attempts to use `--ve` were not working due to:

ade: error: ambiguous option: --ve could match --verbose, --version
