### PR TITLE
Use uv venv instead of python venv when available

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -3,6 +3,7 @@ argvalues
 bindep
 bindir
 bthornto
+caplog
 capsys
 cauthor
 cdescription

--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -12,3 +12,4 @@ ruff
 toml-sort
 tox
 types-PyYAML
+uv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,6 @@ repos:
     rev: v3.1.0
     hooks:
       - id: add-trailing-comma
-        args:
-          - --py36-plus
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks.git
     rev: v1.5.5
@@ -101,11 +99,12 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - pytest
           - pip
+          - pytest
           - subprocess_tee
           - types-pyyaml
           - types-setuptools
+          - uv
         # Override default pre-commit '--ignore-missing-imports'
         args: [--strict]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ For more information about communication, see the [Ansible communication guide](
 - Checks for missing system packages
 - Symlinks the current collection into the current python interpreter's site-packages
 - Install all collection collection dependencies into the current python interpreter's site-packages
+- Uses `uv env` instead of python's venv when available to boost performance. Can be disabled with `SKIP_UV=1`
 
 By placing collections into the python site-packages directory they are discoverable by ansible as well as python and pytest.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ allow-init-docstring = true
 arg-type-hints-in-docstring = false
 baseline = ".config/pydoclint-baseline.txt"
 check-return-types = false
-exclude = '\.git|\.tox|build|out|venv'
+exclude = '\.git|\.tox|\.venv|build|out|venv'
 should-document-private-class-attributes = true
 show-filenames-in-every-violation-message = true
 skip-checking-short-docstrings = false
@@ -355,6 +355,9 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.pylint]
+max-args = 6 # 5 is the default
 
 [tool.setuptools.dynamic]
 dependencies = {file = [".config/requirements.in"]}

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -505,10 +505,7 @@ class Installer:
         msg = "Installing python requirements."
         self._output.info(msg)
 
-        command = (
-            f"{self._config.venv_interpreter} -m pip install"
-            f" -r {self._config.discovered_python_reqs}"
-        )
+        command = f"{self._config.pip_cmd} install" f" -r {self._config.discovered_python_reqs}"
 
         msg = f"Installing python requirements from {self._config.discovered_python_reqs}"
         self._output.debug(msg)

--- a/src/ansible_dev_environment/utils.py
+++ b/src/ansible_dev_environment/utils.py
@@ -112,7 +112,7 @@ class Ansi:
     GREY = "\x1b[90m"
 
 
-def subprocess_run(  # noqa: PLR0913  # pylint: disable=too-many-positional-arguments
+def subprocess_run(  # pylint: disable=too-many-positional-arguments
     command: str,
     verbose: int,
     msg: str,

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -739,7 +739,7 @@ def test_collection_pre_install(
 
 @pytest.mark.parametrize("first", (True, False), ids=["editable", "not_editable"])
 @pytest.mark.parametrize("second", (True, False), ids=["editable", "not_editable"])
-def test_reinstall_local_collection(  # noqa: PLR0913  # pylint: disable=too-many-positional-arguments
+def test_reinstall_local_collection(  # pylint: disable=too-many-positional-arguments
     first: bool,  # noqa: FBT001
     second: bool,  # noqa: FBT001
     tmp_path: Path,


### PR DESCRIPTION
Adds a huge speed boost in creating virtualenv by taking advantage of uv when it is found as being installed.
