### PR TITLE
Use current python interpreter to run builder

### DIFF
--- a/src/ansible_dev_environment/utils.py
+++ b/src/ansible_dev_environment/utils.py
@@ -11,6 +11,7 @@ import threading
 import time
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import subprocess_tee
@@ -18,7 +19,6 @@ import yaml
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from types import TracebackType
 
     from .config import Config
@@ -280,12 +280,25 @@ def collect_manifests(  # noqa: C901
 def builder_introspect(config: Config, output: Output) -> None:
     """Introspect a collection.
 
+    Default to the path of ansible-builder adjacent to the python executable.
+    Since ansible-builder is a dependency of ade, it should be in the same bin directory
+    as the python interpreter that spawned the ade process.
+    If not found, we cannot introspect.
+
     Args:
         config: The configuration object.
         output: The output object.
     """
+    builder_path = Path(sys.executable).parent / "ansible-builder"
+    if not builder_path.exists():
+        output.critical(
+            "Failed to find ansible-builder. Please check the installation"
+            " of ade as it should have been installed by default.",
+        )
+        return  # pragma: no cover
+
     command = (
-        f"ansible-builder introspect {config.site_pkg_path}"
+        f"{builder_path} introspect {config.site_pkg_path}"
         f" --write-pip {config.discovered_python_reqs}"
         f" --write-bindep {config.discovered_bindep_reqs}"
         " --sanitize"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -161,8 +161,8 @@ def test_builder_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     builder_introspect(cfg, output)
 
-    assert config.discovered_bindep_reqs.exists() is True
-    assert config.discovered_python_reqs.exists() is True
+    assert cfg.discovered_bindep_reqs.exists() is True
+    assert cfg.discovered_python_reqs.exists() is True
 
 
 def test_builder_not_found(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -163,33 +163,3 @@ def test_builder_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert cfg.discovered_bindep_reqs.exists() is True
     assert cfg.discovered_python_reqs.exists() is True
-
-
-def test_builder_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test builder not found raises a system exit.
-
-    Args:
-        monkeypatch: The pytest Monkeypatch fixture
-
-    Raises:
-        AssertionError: When the exit code is not 1
-    """
-
-    def exists(_self: Path) -> bool:
-        """Mock path exists.
-
-        Args:
-            _self: The path object
-
-        Returns:
-            False indicating the path does not exist
-
-        """
-        return False
-
-    monkeypatch.setattr(Path, "exists", exists)
-
-    with pytest.raises(SystemExit) as exc_info:
-        builder_introspect(config, output)
-
-    assert exc_info.value.code == 1


### PR DESCRIPTION
Rather than rely on builder being in the PATH, use the python interpreter that spawned the ade process.

This was encountered when installing ade as a uv tool, since builder was not in the current PATH, although it was installed in the ade venv.