### PR TITLE
Utilize uv if available

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,3 +1,4 @@
 ansible-builder
+bindep
 pyyaml
 subprocess-tee

--- a/src/ansible_dev_environment/subcommands/checker.py
+++ b/src/ansible_dev_environment/subcommands/checker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 
 from typing import TYPE_CHECKING
 
@@ -183,7 +184,7 @@ class Checker:
         msg = "Checking system packages."
         self._output.info(msg)
 
-        command = f"bindep -b -f {self._config.discovered_bindep_reqs}"
+        command = f"{sys.executable} -m bindep -b -f {self._config.discovered_bindep_reqs}"
         work = "Checking system package requirements"
         try:
             subprocess_run(

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -124,7 +124,7 @@ class Installer:
             return
         msg = "Installing ansible-core."
         self._output.debug(msg)
-        command = f"{self._config.venv_interpreter} -m pip install ansible-core"
+        command = f"{self._config.venv_pip_install_cmd} ansible-core"
         try:
             subprocess_run(
                 command=command,
@@ -146,7 +146,7 @@ class Installer:
             return
         msg = "Installing ansible-dev-tools."
         self._output.debug(msg)
-        command = f"{self._config.venv_interpreter} -m pip install ansible-dev-tools"
+        command = f"{self._config.venv_pip_install_cmd} ansible-dev-tools"
         try:
             subprocess_run(
                 command=command,
@@ -522,7 +522,7 @@ class Installer:
         msg = "Installing python requirements."
         self._output.info(msg)
 
-        command = f"{self._config.pip_cmd} install -r {self._config.discovered_python_reqs}"
+        command = f"{self._config.venv_pip_install_cmd} -r {self._config.discovered_python_reqs}"
 
         msg = f"Installing python requirements from {self._config.discovered_python_reqs}"
         self._output.debug(msg)

--- a/src/ansible_dev_environment/utils.py
+++ b/src/ansible_dev_environment/utils.py
@@ -11,6 +11,7 @@ import threading
 import time
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import subprocess_tee
@@ -18,7 +19,6 @@ import yaml
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from types import TracebackType
 
     from .config import Config
@@ -280,12 +280,25 @@ def collect_manifests(  # noqa: C901
 def builder_introspect(config: Config, output: Output) -> None:
     """Introspect a collection.
 
+    Default to the path of ansible-builder adjacent to the python executable.
+    Since ansible-builder is a dependency of ade, it should be in the same bin directory
+    as the python interpreter that spawned the ade process.
+    If not found, we cannot introspect.
+
     Args:
         config: The configuration object.
         output: The output object.
     """
+    builder_path = Path(sys.executable).parent / "ansible-builder"
+    if not builder_path.exists():
+        output.critical(
+            "Failed to find ansible-builder. Please check the installation"
+            " of ade as it should have been installed by default.",
+        )
+        return  # pragma: no cover
+
     command = (
-        f"ansible-builder introspect {config.site_pkg_path}"
+        f"{builder_path} introspect {config.site_pkg_path}"
         f" --write-pip {config.discovered_python_reqs}"
         f" --write-bindep {config.discovered_bindep_reqs}"
         " --sanitize"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -161,8 +161,8 @@ def test_builder_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     builder_introspect(cfg, output)
 
-    assert config.discovered_bindep_reqs.exists() is True
-    assert config.discovered_python_reqs.exists() is True
+    assert cfg.discovered_bindep_reqs.exists() is True
+    assert cfg.discovered_python_reqs.exists() is True
 
 
 def test_builder_not_found(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -163,33 +163,3 @@ def test_builder_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert cfg.discovered_bindep_reqs.exists() is True
     assert cfg.discovered_python_reqs.exists() is True
-
-
-def test_builder_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test builder not found raises a system exit.
-
-    Args:
-        monkeypatch: The pytest Monkeypatch fixture
-
-    Raises:
-        AssertionError: When the exit code is not 1
-    """
-
-    def exists(_self: Path) -> bool:
-        """Mock path exists.
-
-        Args:
-            _self: The path object
-
-        Returns:
-            False indicating the path does not exist
-
-        """
-        return False
-
-    monkeypatch.setattr(Path, "exists", exists)
-
-    with pytest.raises(SystemExit) as exc_info:
-        builder_introspect(config, output)
-
-    assert exc_info.value.code == 1


### PR DESCRIPTION
- There were a few instances where `python -m pip` was still being used rather than `uv`
- Log the `uv` command using the output class rather than the logger such that the user can see it
- Add `bindep` as a direct dep since it's required for system package assessment
- Call `builder` and `bindep` using the same python interpreter that spawned the `ade` process.