### PR TITLE
Add isolation options

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -27,6 +27,7 @@ reqs
 sessionstart
 setenv
 treemaker
+unisolated
 usefixtures
 xdist
 xmltodict

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -203,6 +203,20 @@ def parse() -> argparse.Namespace:
         help="Install seed packages inside the virtual environment (ansible-dev-tools).",
     )
 
+    install.add_argument(
+        "--im",
+        "--isolation-mode",
+        dest="isolation_mode",
+        help=(
+            "Isolation mode to use. restrictive: Exit if collections are found in ansible home or the system collection directory. "
+            " cfg: Update or add an ansible.cfg file in the current working directory to isolate the workspace"
+            " none: No isolation, not recommended."
+        ),
+        default="restrictive",
+        choices=["restrictive", "cfg", "none"],
+        type=str,
+    )
+
     _uninstall = subparsers.add_parser(
         "uninstall",
         formatter_class=CustomHelpFormatter,

--- a/src/ansible_dev_environment/definitions.py
+++ b/src/ansible_dev_environment/definitions.py
@@ -1,0 +1,86 @@
+"""Some common definitions."""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class AnsibleCfg:
+    """ansible.cfg file abstraction.
+
+    Attributes:
+        path: Path to the ansible.cfg file.
+    """
+
+    path: Path
+
+    @property
+    def exists(self) -> bool:
+        """Check if the ansible.cfg file exists."""
+        return self.path.exists()
+
+    @property
+    def collections_path_is_dot(self) -> bool:
+        """Check if the collection path is a dot.
+
+        Returns:
+            bool: True if the collection path is a dot.
+        """
+        config = ConfigParser()
+        config.read(self.path)
+        return config.get("defaults", "collections_path", fallback=None) == "."
+
+    def set_or_update_collection_path(self) -> None:
+        """Set or update the collection path in the ansible.cfg file.
+
+        The configparser doesn't preserve comments, so we need to read the file
+        and write it back with the new collection path.
+        """
+        config = ConfigParser()
+        config.read(self.path)
+        if not config.has_section("defaults"):
+            with self.path.open(mode="r+") as file:
+                content_str = file.read()
+                file.seek(0, 0)
+                file.truncate()
+                file.write("[defaults]\ncollections_path = .\n" + content_str)
+                file.write("\n")
+            return
+
+        if not config.has_option("defaults", "collections_path"):
+            with self.path.open(mode="r+") as file:
+                content_list = file.read().splitlines()
+                idx = content_list.index("[defaults]") + 1
+                content_list.insert(idx, "collections_path = .")
+                file.seek(0, 0)
+                file.truncate()
+                file.write("\n".join(content_list))
+                file.write("\n")
+            return
+
+        with self.path.open(mode="r+") as file:
+            content_list = file.read().splitlines()
+            idx = next(
+                i for i, line in enumerate(content_list) if line.startswith("collections_path")
+            )
+            content_list[idx] = "collections_path = ."
+            file.seek(0, 0)
+            file.truncate()
+            file.write("\n".join(content_list))
+            file.write("\n")
+        return
+
+    def author_new(self) -> None:
+        """Author the file and update it."""
+        config = ConfigParser()
+        config.add_section("defaults")
+        config.set("defaults", "collections_path", ".")
+        with self.path.open(mode="w") as f:
+            config.write(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,7 +212,7 @@ def session_venv(session_dir: Path, monkey_session: pytest.MonkeyPatch) -> Confi
     cli.parse_args()
     cli.init_output()
     cli.args_sanity()
-    cli.ensure_isolated()
+    cli.isolation_check()
     with pytest.raises(SystemExit):
         cli.run()
     return cli.config
@@ -257,7 +257,7 @@ def function_venv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
     cli.parse_args()
     cli.init_output()
     cli.args_sanity()
-    cli.ensure_isolated()
+    cli.isolation_check()
     with pytest.raises(SystemExit):
         cli.run()
     return cli.config

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -266,7 +266,7 @@ def test_exit_code_one(
     cli.init_output()
     cli.output.error("Test error")
     with pytest.raises(SystemExit) as excinfo:
-        cli._exit()
+        cli.exit()
     expected = 1
     assert excinfo.value.code == expected
     captured = capsys.readouterr()
@@ -292,7 +292,7 @@ def test_exit_code_two(
     cli.init_output()
     cli.output.warning("Test warning")
     with pytest.raises(SystemExit) as excinfo:
-        cli._exit()
+        cli.exit()
     expected = 2
     assert excinfo.value.code == expected
     captured = capsys.readouterr()


### PR DESCRIPTION
Rename the current isolation approach to restrictive, set as default.
Add new isolation options, cfg and none.
- cfg adds or updates the ansible.cfg file in the user home or CWD
- none, although a bad idea, does not check for isolation

tests to follow
