### PR TITLE
Add environment variable support for select parameters

### DIFF
--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -23,12 +23,12 @@ if TYPE_CHECKING:
 
 
 ENVVAR_MAPPING: dict[str, str] = {
+    "ansi": "NO_COLOR",
     "isolation_mode": "ADE_ISOLATION_MODE",
     "seed": "ADE_SEED",
     "uv": "ADE_UV",
-    "verbose": "ADE_VERBOSE",
-    "ansi": "NO_COLOR",
     "venv": "VIRTUAL_ENV",
+    "verbose": "ADE_VERBOSE",
 }
 
 try:
@@ -305,9 +305,9 @@ def apply_envvars(args: list[str], parser: ArgumentParser) -> argparse.Namespace
             raise NotImplementedError(err)
 
         present = any(
-            o
-            for o in action.option_strings
-            if any(arg for arg in args if arg.startswith(o.split()[0]))
+            option
+            for option in action.option_strings
+            if any(arg for arg in args if arg.startswith(option.split()[0]))
         )
         envvar_value = os.environ.get(envvar)
 
@@ -321,14 +321,14 @@ def apply_envvars(args: list[str], parser: ArgumentParser) -> argparse.Namespace
             if envvar == "NO_COLOR" and envvar_value != "":
                 final_value = False
             elif isinstance(action, (argparse.BooleanOptionalAction, argparse._StoreTrueAction)):  # noqa: SLF001
-                final_value = str_to_bool(envvar_value)
                 named_type = "boolean"
+                final_value = str_to_bool(envvar_value)
             elif isinstance(action, argparse._CountAction) or action.type is int:  # noqa: SLF001
-                final_value = int(envvar_value)
                 named_type = "int"
+                final_value = int(envvar_value)
             elif action.type is str or action.type is None:
-                final_value = envvar_value
                 named_type = "str"
+                final_value = envvar_value
             else:
                 err = f"Action type {action.type} not implemented for envvar {envvar}"
                 raise NotImplementedError(err)

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import logging
 import os
 import sys
@@ -12,11 +13,23 @@ from argparse import HelpFormatter
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .utils import str_to_bool
+
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from typing import Any
+
+
+ENVVAR_MAPPING: dict[str, str] = {
+    "isolation_mode": "ADE_ISOLATION_MODE",
+    "seed": "ADE_SEED",
+    "uv": "ADE_UV",
+    "verbose": "ADE_VERBOSE",
+    "ansi": "NO_COLOR",
+    "venv": "VIRTUAL_ENV",
+}
 
 try:
     from ._version import version as __version__  # type: ignore[unused-ignore,import-not-found]
@@ -40,6 +53,14 @@ def common_args(parser: ArgumentParser) -> None:
         parser: The parser to add the arguments to
     """
     parser.add_argument(
+        "--ansi",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        dest="ansi",
+        help="Enable or disable the use of ANSI codes for terminal hyperlink generation and color.",
+    )
+
+    parser.add_argument(
         "--lf",
         "--log-file <file>",
         dest="log_file",
@@ -61,6 +82,13 @@ def common_args(parser: ArgumentParser) -> None:
         choices=["true", "false"],
         default="true",
         help="Append to log file.",
+    )
+    parser.add_argument(
+        "--uv",
+        dest="uv",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable or disable the use of uv as the python package manager if found.",
     )
     parser.add_argument(
         "-v",
@@ -101,12 +129,9 @@ def parse() -> argparse.Namespace:
 
     level1 = ArgumentParser(add_help=False)
 
-    venv_path = os.environ.get("VIRTUAL_ENV", None)
-    if not venv_path:
-        warnings.warn("No virtualenv found active, we will assume .venv", stacklevel=1)
     level1.add_argument(
         "--venv <directory>",
-        help="Target virtual environment.",
+        help="Target virtual environment. Created with 'ade install' if not found.",
         default=".venv",
         dest="venv",
     )
@@ -117,15 +142,6 @@ def parse() -> argparse.Namespace:
         help="Pre install collections from source, reads source-requirements.yml file.",
         default=False,
         action="store_true",
-    )
-
-    level1.add_argument(
-        "--na",
-        "--no-ansi",
-        action="store_true",
-        default=False,
-        dest="no_ansi",
-        help="Disable the use of ANSI codes for terminal hyperlink generation and color.",
     )
 
     level1.add_argument(
@@ -195,7 +211,6 @@ def parse() -> argparse.Namespace:
     )
 
     install.add_argument(
-        # "-adt",
         "--seed",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -229,13 +244,102 @@ def parse() -> argparse.Namespace:
         _group_titles(subparser)
 
     args = sys.argv[1:]
-    for i, v in enumerate(args):
-        for old in ("-adt", "--ansible-dev-tools"):
-            if v == old:
-                msg = f"Replace the deprecated {old} argument with --seed to avoid future execution failure."
-                logger.warning(msg)
-                args[i] = "--seed"
-    return parser.parse_args(args)
+    for param in ("--adt", "--ansible-dev-tools"):
+        with contextlib.suppress(ValueError):
+            args[args.index(param)] = "--seed"
+            err = f"The parameter '{param}' is deprecated, use 'ADE_SEED or '--seed' instead."
+            warnings.warn(err, DeprecationWarning, stacklevel=2)
+
+    if skip_uv := os.environ.get("SKIP_UV"):
+        os.environ["ADE_UV"] = skip_uv
+        err = "The environment variable 'SKIP_UV' is deprecated, use 'ADE_UV' or '--no-uv' instead."
+        warnings.warn(err, DeprecationWarning, stacklevel=2)
+
+    return apply_envvars(args=args, parser=parser)
+
+
+def _get_action(actions: list[argparse.Action], dest: str) -> argparse.Action | None:
+    """Get the action for a given destination.
+
+    Args:
+        actions: The list of actions
+        dest: The destination to get the action for
+
+    Returns:
+        The action for the given destination
+
+    """
+    for action in actions:
+        if action.dest == dest:
+            return action
+        if isinstance(action, argparse._SubParsersAction):  # noqa: SLF001
+            for subparser in action.choices.values():
+                sub_action = _get_action(subparser._actions, dest)  # noqa: SLF001
+                if sub_action is not None:
+                    return sub_action
+
+    return None
+
+
+def apply_envvars(args: list[str], parser: ArgumentParser) -> argparse.Namespace:
+    """Apply the environment variables to the arguments.
+
+    Special handling exists NO_COLOR since it's value shouldn't matter.
+    Also account for a space in some option strings when checking for presence in sys.argv.
+
+    Args:
+        args: The cli arguments
+        parser: The argument parser
+
+    Returns:
+        The resulting namespace
+
+    Raises:
+        NotImplementedError: If the action type is not implemented
+    """
+    cli_result = parser.parse_args(args)
+
+    for dest, envvar in ENVVAR_MAPPING.items():
+        if (action := _get_action(parser._actions, dest)) is None:  # noqa: SLF001
+            err = f"Action for {dest} not found in parser"
+            raise NotImplementedError(err)
+
+        present = any(o for o in action.option_strings if o.split()[0] in args)
+        envvar_value = os.environ.get(envvar)
+
+        if present or envvar_value is None:
+            continue
+
+        final_value: bool | int | str | None = None
+        named_type = "not set"
+
+        with contextlib.suppress(ValueError):
+            if envvar == "NO_COLOR" and envvar_value != "":
+                final_value = False
+            elif isinstance(action, (argparse.BooleanOptionalAction, argparse._StoreTrueAction)):  # noqa: SLF001
+                final_value = str_to_bool(envvar_value)
+                named_type = "boolean"
+            elif isinstance(action, argparse._CountAction) or action.type is int:  # noqa: SLF001
+                final_value = int(envvar_value)
+                named_type = "int"
+            elif action.type is str or action.type is None:
+                final_value = envvar_value
+                named_type = "str"
+            else:
+                err = f"Action type {action.type} not implemented for envvar {envvar}"
+                raise NotImplementedError(err)
+
+        err = f"ade: error: environment variable {envvar}: invalid value: '{envvar_value}' "
+        if final_value is None:
+            err += f"could not convert to {named_type}\n"
+            parser.exit(1, err)
+        if action.choices and final_value not in action.choices:
+            err += f"(choose from {', '.join(map(repr, action.choices))})\n"
+            parser.exit(1, err)
+
+        setattr(cli_result, dest, final_value)
+
+    return cli_result
 
 
 def _group_titles(parser: ArgumentParser) -> None:
@@ -266,6 +370,9 @@ class ArgumentParser(argparse.ArgumentParser):
         """
         if "choices" in kwargs:
             kwargs["help"] += f" (choices: {', '.join(kwargs['choices'])})"
+        if kwargs.get("dest") in ENVVAR_MAPPING:
+            envvar = ENVVAR_MAPPING[kwargs["dest"]]
+            kwargs["help"] += f" (env: {envvar})"
         if "default" in kwargs and kwargs["default"] != "==SUPPRESS==":
             kwargs["help"] += f" (default: {kwargs['default']})"
         kwargs["help"] = kwargs["help"][0].upper() + kwargs["help"][1:]

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -304,7 +304,11 @@ def apply_envvars(args: list[str], parser: ArgumentParser) -> argparse.Namespace
             err = f"Action for {dest} not found in parser"
             raise NotImplementedError(err)
 
-        present = any(o for o in action.option_strings if o.split()[0] in args)
+        present = any(
+            o
+            for o in action.option_strings
+            if any(arg for arg in args if arg.startswith(o.split()[0]))
+        )
         envvar_value = os.environ.get(envvar)
 
         if present or envvar_value is None:

--- a/src/ansible_dev_environment/cli.py
+++ b/src/ansible_dev_environment/cli.py
@@ -51,8 +51,8 @@ class Cli:
             self.term_features = TermFeatures(color=False, links=False)
         else:
             self.term_features = TermFeatures(
-                color=False if os.environ.get("NO_COLOR") else not self.args.no_ansi,
-                links=not self.args.no_ansi,
+                color=self.args.ansi,
+                links=self.args.ansi,
             )
 
         self.output = Output(
@@ -97,6 +97,10 @@ class Cli:
         ):
             err = "Editable can not be used with a requirements file."
             self.output.critical(err)
+
+        self.output.debug("Arguments sanity check passed.")
+        for arg in vars(self.args):
+            self.output.debug(f"{arg}: {getattr(self.args, arg)}")
 
     def isolation_check(self) -> bool:
         """Check the environment for isolation.

--- a/src/ansible_dev_environment/utils.py
+++ b/src/ansible_dev_environment/utils.py
@@ -520,3 +520,24 @@ class Spinner:  # pylint: disable=too-many-instance-attributes
             sys.stdout.write("\r")
         # show the cursor
         sys.stdout.write("\033[?25h")
+
+
+def str_to_bool(value: str) -> bool | None:
+    """Converts a string to a boolean based on common truthy and falsy values.
+
+    Args:
+        value: The string to convert.
+
+    Returns:
+        True for truthy values, False for falsy values, None for invalid values.
+    """
+    truthy_values = {"true", "1", "yes", "y", "on"}
+    falsy_values = {"false", "0", "no", "n", "off"}
+
+    value_lower = value.strip().lower()
+
+    if value_lower in truthy_values:
+        return True
+    if value_lower in falsy_values:
+        return False
+    return None

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -58,7 +58,7 @@ def test_venv(
             str(tmp_path / "cisco.nxos"),
             "--venv=venv",
             "--no-ansi",
-            "--site-system-packages",
+            "--system-site-packages",
         ],
     )
     with pytest.raises(SystemExit):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -58,6 +58,7 @@ def test_venv(
             str(tmp_path / "cisco.nxos"),
             "--venv=venv",
             "--no-ansi",
+            "--site-system-packages",
         ],
     )
     with pytest.raises(SystemExit):
@@ -66,6 +67,7 @@ def test_venv(
     captured = capsys.readouterr()
 
     assert string in captured.out
+    assert "with system site packages" in captured.out
 
     monkeypatch.setattr(
         "sys.argv",

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -59,6 +59,7 @@ def test_venv(
             "--venv=venv",
             "--no-ansi",
             "--system-site-packages",
+            "-vvv",
         ],
     )
     with pytest.raises(SystemExit):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -58,8 +58,6 @@ def test_venv(
             str(tmp_path / "cisco.nxos"),
             "--venv=venv",
             "--no-ansi",
-            "--system-site-packages",
-            "-vvv",
         ],
     )
     with pytest.raises(SystemExit):
@@ -68,7 +66,6 @@ def test_venv(
     captured = capsys.readouterr()
 
     assert string in captured.out
-    assert "with system site packages" in captured.out
 
     monkeypatch.setattr(
         "sys.argv",
@@ -216,3 +213,34 @@ def test_requirements(
     assert "ansible.netcommon" not in captured.out
     assert "ansible.scm" not in captured.out
     assert "ansible.utils" in captured.out
+
+
+def test_system_site_packages(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Install non-local collection.
+
+    Args:
+        capsys: Capture stdout and stderr
+        tmp_path: Temporary directory
+        monkeypatch: Pytest monkeypatch
+    """
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "ansible.utils",
+            f"--venv={tmp_path / 'venv'}",
+            "--system-site-packages",
+            "--no-ansi",
+            "-vvv",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        main()
+    captured = capsys.readouterr()
+    assert "with system site packages" in captured.out
+    assert "Installed collections include: ansible.utils" in captured.out

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -335,7 +335,7 @@ def test_apply_envvar_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FOO", "42.0")
 
     parser = ArgumentParser()
-    parser.add_argument("--foo", type=float)
+    parser.add_argument("--foo", type=float, help="helpless")
 
     with pytest.raises(NotImplementedError) as excinfo:
         apply_envvars(args=[], parser=parser)

--- a/tests/unit/test_cli_deprecated.py
+++ b/tests/unit/test_cli_deprecated.py
@@ -1,0 +1,46 @@
+"""Test some deprecated values in the CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ansible_dev_environment.cli import main
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_adt(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the seed option.
+
+    Args:
+        capsys: Pytest stdout capture fixture.
+        monkeypatch: Pytest fixture.
+    """
+    # Test the seed option
+    monkeypatch.setattr(
+        "sys.argv",
+        ["ansible-dev-environment", "install", "--adt"],
+    )
+    main(dry=True)
+    captured = capsys.readouterr()
+    assert "'--adt' is deprecated" in captured.out
+
+
+def test_skip_uv(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the skip uv option.
+
+    Args:
+        capsys: Pytest stdout capture fixture.
+        monkeypatch: Pytest fixture.
+    """
+    # Test the skip uv option
+    monkeypatch.setattr(
+        "sys.argv",
+        ["ansible-dev-environment", "install"],
+    )
+    monkeypatch.setenv("SKIP_UV", "1")
+    main(dry=True)
+    captured = capsys.readouterr()
+    assert "'SKIP_UV' is deprecated" in captured.out

--- a/tests/unit/test_cli_precedence.py
+++ b/tests/unit/test_cli_precedence.py
@@ -1,0 +1,75 @@
+"""Test for cli and environment variable precedence."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+
+from ansible_dev_environment.cli import Cli
+
+
+class Data(TypedDict):
+    """Test data dictionary.
+
+    Attributes:
+        attr: Attribute name.
+        args: Command line argument.
+        env: Environment variable name.
+        cli_expected: Expected value from command line argument.
+        env_expected: Expected value from environment variable.
+
+    """
+
+    attr: str
+    args: str
+    env: str
+    cli_expected: bool | int | str
+    env_expected: bool | int | str
+
+
+params: list[Data] = [
+    {
+        "attr": "ansi",
+        "args": "--ansi",
+        "env": "NO_COLOR",
+        "env_expected": False,
+        "cli_expected": True,
+    },
+    {
+        "attr": "seed",
+        "args": "--seed",
+        "env": "ADE_SEED",
+        "env_expected": False,
+        "cli_expected": True,
+    },
+    {"attr": "verbose", "args": "-vvv", "env": "ADE_VERBOSE", "env_expected": 2, "cli_expected": 3},
+    {"attr": "uv", "args": "--uv", "env": "ADE_UV", "env_expected": False, "cli_expected": True},
+]
+
+
+@pytest.mark.parametrize("data", params, ids=lambda d: d["attr"])
+def test_cli_precedence_flag(
+    data: Data,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test CLI precedence over environment variables.
+
+    Args:
+        data: Test data dictionary.
+        monkeypatch: Pytest fixture.
+
+    """
+    cli = Cli()
+
+    args = ["ade", "install"]
+    monkeypatch.setenv(data["env"], str(data["env_expected"]))
+    monkeypatch.setattr("sys.argv", args)
+
+    cli.parse_args()
+
+    assert getattr(cli.args, data["attr"]) == data["env_expected"]
+
+    args.append(data["args"])
+    cli.parse_args()
+    assert getattr(cli.args, data["attr"]) == data["cli_expected"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -284,6 +284,31 @@ def test_venv_from_env_var(
     assert config.venv == venv
 
 
+def test_venv_not_found(
+    output: Output,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test the venv  not found.
+
+    Args:
+        output: The output fixture.
+        capsys: A pytest fixture for capturing stdout and stderr.
+        monkeypatch: A pytest fixture for patching.
+        tmp_path: A temporary directory.
+    """
+    args = gen_args(venv=str(tmp_path / "test_venv"))
+    config = Config(args=args, output=output, term_features=output.term_features)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        config.init()
+
+    assert exc.value.code == 1
+    assert "Critical: Cannot find virtual environment:" in capsys.readouterr().err
+
+
 def test_venv_creation_failed(
     tmp_path: Path,
     output: Output,

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -276,6 +276,8 @@ def test_no_adt_install(
         collection_specifier=None,
         requirement=None,
         cpi=None,
+        subcommand="install",
+        uv=True,
     )
 
     config = Config(args=args, output=output, term_features=output.term_features)
@@ -310,6 +312,8 @@ def test_adt_install(
         collection_specifier=None,
         requirement=None,
         cpi=None,
+        subcommand="install",
+        uv=True,
     )
 
     config = Config(args=args, output=output, term_features=output.term_features)

--- a/tests/unit/test_treemaker.py
+++ b/tests/unit/test_treemaker.py
@@ -65,6 +65,8 @@ def test_tree_empty(
     args = Namespace(
         venv=venv_path,
         verbose=0,
+        subcommand="tree",
+        uv=True,
     )
     output._verbosity = 0
     config = Config(args=args, output=output, term_features=output.term_features)
@@ -96,6 +98,8 @@ def test_tree_malformed_info(
     args = Namespace(
         venv=venv_path,
         verbose=0,
+        subcommand="tree",
+        uv=True,
     )
 
     def collect_manifests(
@@ -151,6 +155,8 @@ def test_tree_malformed_deps(
     args = Namespace(
         venv=venv_path,
         verbose=0,
+        subcommand="tree",
+        uv=True,
     )
 
     def collect_manifests(
@@ -208,6 +214,8 @@ def test_tree_malformed_deps_not_string(
     args = Namespace(
         venv=venv_path,
         verbose=0,
+        subcommand="tree",
+        uv=True,
     )
 
     def collect_manifests(
@@ -262,10 +270,7 @@ def test_tree_malformed_repo_not_string(
     venv_path = tmp_path / "venv"
     SafeEnvBuilder().create(venv_path)
 
-    args = Namespace(
-        venv=venv_path,
-        verbose=0,
-    )
+    args = Namespace(venv=venv_path, verbose=0, subcommand="tree", uv=True)
 
     def collect_manifests(
         target: Path,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -125,12 +125,17 @@ def test_parse_collection_request(scenario: tuple[str, Collection | None]) -> No
         assert parse_collection_request(string=string, config=config, output=output) == spec
 
 
-def test_builder_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_builder_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    session_venv: Config,
+) -> None:
     """Test that builder is found.
 
     Args:
         tmp_path: A temporary path
         monkeypatch: The pytest Monkeypatch fixture
+        session_venv: The session venv
 
     Raises:
         AssertionError: if either file is not found
@@ -150,7 +155,13 @@ def test_builder_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(Config, "cache_dir", cache_dir)
 
-    args = Namespace(venv=str(tmp_path / ".venv"), system_site_packages=False, verbose=0)
+    args = Namespace(
+        venv=session_venv.venv,
+        system_site_packages=False,
+        verbose=0,
+        subcommand="check",
+        uv=True,
+    )
 
     cfg = Config(
         args=args,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,7 +13,7 @@ from ansible_dev_environment.collection import (
 )
 from ansible_dev_environment.config import Config
 from ansible_dev_environment.output import Output
-from ansible_dev_environment.utils import TermFeatures, builder_introspect
+from ansible_dev_environment.utils import TermFeatures, builder_introspect, str_to_bool
 
 
 term_features = TermFeatures(color=False, links=False)
@@ -174,3 +174,25 @@ def test_builder_found(
 
     assert cfg.discovered_bindep_reqs.exists() is True
     assert cfg.discovered_python_reqs.exists() is True
+
+
+def test_str_to_bool() -> None:
+    """Test the str_to_bool function.
+
+    This function tests the conversion of string values to boolean values.
+    """
+    assert str_to_bool("true") is True
+    assert str_to_bool("True") is True
+    assert str_to_bool("1") is True
+    assert str_to_bool("yes") is True
+    assert str_to_bool("y") is True
+    assert str_to_bool("on") is True
+
+    assert str_to_bool("false") is False
+    assert str_to_bool("False") is False
+    assert str_to_bool("0") is False
+    assert str_to_bool("no") is False
+    assert str_to_bool("n") is False
+    assert str_to_bool("off") is False
+
+    assert str_to_bool("anything else") is None


### PR DESCRIPTION
Create a mapping between environment variables and an argparse `dest`.  To preserve a CLI->ENV->default order of precedence we'll look for each of the mapping's option strings in the cli paramters.  If provided on the CLI, ignore the enviroment variable.  If not provided use an enviroment variable if set.

Environment variable are added to their respective attribute help string.

All ADE specific enviroment variables are prefaced with `ADE_` to avoid a conflict with other applicaitons.

This moves  and renames the `SKIP_UV` enviroment variables out to the parser as `ADE_UV` and adds a command line parameter to match (#278) Backward compatible support was added.

This also revises the use of `VIRTUAL_ENV` such that it is the enviroment variable for the `--venv` command line paramter and used if `--venv` if not provided by the user. (#276).  The venv will default to `.venv` unless VIRTUAL_ENV is set.

This cleans up the `NO_COLOR` enviroment varaible such that it is now the enviroment variable which cooresponds to the `--ansi` command line parameter.

Added support for `ADE_ISOLATION_MODE` mapped to `--isolation_mode`
Added support for `ADE_VERBOSE` mapped to `-v` 


Tests updated as needed, largley due the correction of precedense and handling of a non existent venv, as virtual enviroments are now only build when the subcommand is `install`

Additional tests forthcoming for new code.



