### PR TITLE
Enable cli tab completion

### DIFF
--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -1,3 +1,4 @@
+argcomplete
 coverage[toml]
 mypy
 pip-tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,7 @@ repos:
         args:
           - --output-format=colorized
         additional_dependencies:
+          - argcomplete
           - pytest
           - pyyaml
           - subprocess_tee
@@ -91,6 +92,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - argcomplete
           - pip
           - pytest
           - subprocess_tee

--- a/src/ansible_dev_environment/arg_parser.py
+++ b/src/ansible_dev_environment/arg_parser.py
@@ -16,6 +16,14 @@ from typing import TYPE_CHECKING
 from .utils import str_to_bool
 
 
+try:
+    import argcomplete
+
+    HAS_ARGCOMPLETE = True
+except ImportError:  # pragma: no cover
+    HAS_ARGCOMPLETE = False
+
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -254,6 +262,9 @@ def parse() -> argparse.Namespace:
         os.environ["ADE_UV"] = skip_uv
         err = "The environment variable 'SKIP_UV' is deprecated, use 'ADE_UV' or '--no-uv' instead."
         warnings.warn(err, DeprecationWarning, stacklevel=2)
+
+    if HAS_ARGCOMPLETE:
+        argcomplete.autocomplete(parser)
 
     return apply_envvars(args=args, parser=parser)
 

--- a/src/ansible_dev_environment/cli.py
+++ b/src/ansible_dev_environment/cli.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 """CLI entrypoint."""
 
 from __future__ import annotations


### PR DESCRIPTION
```
ade --l
--log-append <bool>  --la  -- Append to log file. (choices: true, false) (default: true)                                                                                                           
--log-file <file>    --lf  -- Log file to write to. (default: /home/bthornto/github/ansible-dev-environment/ansible-dev-environment.log)                                                           
--log-level <level>  --ll  -- Log level for file output. (choices: notset, debug, info, warning, error, critical) (default: notset)    
```

docs to be added later with forthcoming docs work

Left as an opt-in for now.

[AAP-30795](https://issues.redhat.com/browse/AAP-30795)