### PR TITLE
Disable output formatting with `--no-ansi`

### DIFF
--- a/src/ansible_dev_environment/output.py
+++ b/src/ansible_dev_environment/output.py
@@ -133,6 +133,14 @@ class Level(Enum):
         """
         return f"{' ' * (self._longest_name() - len(self.name))}{self.name.capitalize()}: "
 
+    def simple(self) -> str:
+        """Simple formatting for level name.
+
+        Returns:
+            The level name
+        """
+        return f"{self.name.capitalize()}: "
+
 
 @dataclass
 class Msg:
@@ -180,6 +188,10 @@ class Msg:
 
         lines = []
         message_lines = self.message.splitlines()
+
+        # --no-ansi, will set color to false, so assume minimal formatting
+        if not color:
+            return [self.prefix.simple() + message_lines[0], *message_lines[1:]]
 
         lines.extend(
             textwrap.fill(


### PR DESCRIPTION
As a result of a random test failure locally due to output formatting, it was found that `--no-ansi` still did some indenting of output.

This makes the output very basic when either `--no-ansi` or NO_COLOR is used.

Before:
```
   Debug: Checking dependencies for ansible.posix.
   Debug: Collection ansible.posix has no dependencies.
   Debug: Checking dependencies for ansible.scm.
   Debug: Collection ansible.scm requires ansible.utils >=3.0.0 and ansible.utils 5.1.2 is installed.
   Debug: Checking dependencies for ansible.utils.
   Debug: Collection ansible.utils has no dependencies.
    Note: All dependant collections are installed.
    Info: Checking system packages.
   Debug: Running command: /home/bthornto/github/ansible-dev-environment/.venv/bin/python3 -m bindep -b -f
          /home/bthornto/github/ansible-dev-environment/.venv/.ansible-dev-environment/discovered_bindep.txt
```

After:
```Debug: Checking dependencies for ansible.posix.
Debug: Collection ansible.posix has no dependencies.
Debug: Checking dependencies for ansible.scm.
Debug: Collection ansible.scm requires ansible.utils >=3.0.0 and ansible.utils 5.1.2 is installed.
Debug: Checking dependencies for ansible.utils.
Debug: Collection ansible.utils has no dependencies.
Note: All dependant collections are installed.
Info: Checking system packages.
Debug: Running command: /home/bthornto/github/ansible-dev-environment/.venv/bin/python3 -m bindep -b -f /home/bthornto/github/ansible-dev-environment/.venv/.ansible-dev-environment/discovered_bindep.txt
``` 