### PR TITLE
Fix ansible-core version preservation during ansible-dev-tools installation

### DIFF
--- a/src/ansible_dev_environment/config.py
+++ b/src/ansible_dev_environment/config.py
@@ -74,15 +74,26 @@ class Config:  # pylint: disable=too-many-instance-attributes
         return self.cache_dir
 
     @property
-    def venv_pip_install_cmd(self) -> str:
+    def venv_pip_cmd(self) -> str:
         """Return the pip command for the virtual environment.
+
+        Returns:
+            The pip command for the virtual environment.
+        """
+        if self.uv_available:
+            return "uv pip"
+        return f"{self.venv}/bin/python -m pip"
+
+    @property
+    def venv_pip_install_cmd(self) -> str:
+        """Return the pip install command for the virtual environment.
 
         Returns:
             The pip install command for the virtual environment.
         """
         if self.uv_available:
-            return f"uv pip install --python {self.venv_interpreter}"
-        return f"{self.venv}/bin/python -m pip install"
+            return f"{self.venv_pip_cmd} install --python {self.venv_interpreter}"
+        return f"{self.venv_pip_cmd} install"
 
     @cached_property
     def uv_available(self) -> bool:

--- a/tests/unit/test_installer_warning.py
+++ b/tests/unit/test_installer_warning.py
@@ -17,7 +17,7 @@ Fixtures:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -25,6 +25,7 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+from ansible_dev_environment.config import Config
 from ansible_dev_environment.output import Output
 from ansible_dev_environment.subcommands.installer import Installer
 from ansible_dev_environment.utils import TermFeatures
@@ -98,7 +99,7 @@ def _installer(test_config: FakeConfig, test_output: Output) -> Installer:
     Returns:
         Installer instance configured for testing
     """
-    return Installer(config=test_config, output=test_output)
+    return Installer(config=cast(Config, test_config), output=test_output)
 
 
 def test_no_warning_when_seed_false(
@@ -584,7 +585,7 @@ def test_integration_with_real_config(
     config.args.seed = True
     config.args.ansible_core_version = "2.15.0"
 
-    installer = Installer(config=config, output=output)
+    installer = Installer(config=cast(Config, config), output=output)
 
     # Verify the dependency constraint function is called
     constraint_calls = []

--- a/tests/unit/test_installer_warning.py
+++ b/tests/unit/test_installer_warning.py
@@ -99,7 +99,7 @@ def _installer(test_config: FakeConfig, test_output: Output) -> Installer:
     Returns:
         Installer instance configured for testing
     """
-    return Installer(config=cast(Config, test_config), output=test_output)
+    return Installer(config=cast("Config", test_config), output=test_output)
 
 
 def test_no_warning_when_seed_false(
@@ -585,7 +585,7 @@ def test_integration_with_real_config(
     config.args.seed = True
     config.args.ansible_core_version = "2.15.0"
 
-    installer = Installer(config=cast(Config, config), output=output)
+    installer = Installer(config=cast("Config", config), output=output)
 
     # Verify the dependency constraint function is called
     constraint_calls = []

--- a/tests/unit/test_installer_warning.py
+++ b/tests/unit/test_installer_warning.py
@@ -1,0 +1,620 @@
+"""Tests for installer dependency constraint warnings.
+
+This module tests the warning functionality in the Installer class that alerts users
+when their requested ansible-core version may be incompatible with ansible-dev-tools
+requirements. It uses pytest with monkeypatch for clean, unittest-free testing.
+
+Classes:
+    FakeArgs: Mock args object for testing configuration
+    FakeConfig: Mock config object for testing installer behavior
+    FakeOutput: Mock output object for capturing warning messages
+
+Fixtures:
+    test_config: Provides a FakeConfig instance for tests
+    test_output: Provides a FakeOutput instance for tests
+    installer: Provides an Installer instance with test dependencies
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ansible_dev_environment.output import Output
+from ansible_dev_environment.subcommands.installer import Installer
+from ansible_dev_environment.utils import TermFeatures
+
+
+class FakeArgs:
+    """Fake args object for testing installer configuration.
+
+    Mimics the argparse.Namespace object that contains CLI arguments
+    passed to the installer.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with default test values."""
+        self.seed: bool = True
+        self.ansible_core_version: str | None = None
+
+
+class FakeConfig:
+    """Fake config object for testing installer behavior.
+
+    Mimics the Config class that provides configuration data to the installer.
+    Contains pip commands and argument configuration.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with default test configuration."""
+        self.venv_pip_cmd: str = "pip"
+        self.venv_pip_install_cmd: str = "pip install"
+        self.args: FakeArgs = FakeArgs()
+
+
+@pytest.fixture(name="test_config")
+def _test_config() -> FakeConfig:
+    """Create a test config object.
+
+    Returns:
+        FakeConfig instance with default test configuration
+    """
+    return FakeConfig()
+
+
+@pytest.fixture(name="test_output")
+def _test_output(tmp_path: Path) -> Output:
+    """Create a real output object for testing.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture
+
+    Returns:
+        Real Output instance for testing
+    """
+    term_features = TermFeatures(color=False, links=False)
+    return Output(
+        log_file=str(tmp_path / "test.log"),
+        log_level="WARNING",
+        log_append="false",
+        term_features=term_features,
+        verbosity=0,
+    )
+
+
+@pytest.fixture(name="installer")
+def _installer(test_config: FakeConfig, test_output: Output) -> Installer:
+    """Create an installer instance with test dependencies.
+
+    Args:
+        test_config: Test configuration object
+        test_output: Real output object for logging
+
+    Returns:
+        Installer instance configured for testing
+    """
+    return Installer(config=test_config, output=test_output)
+
+
+def test_no_warning_when_seed_false(
+    installer: Installer,
+    test_config: FakeConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that no warning is issued when --seed is False.
+
+    When the --seed flag is False, ansible-dev-tools won't be installed,
+    so there's no need to check for version compatibility warnings.
+
+    Args:
+        installer: Installer instance under test
+        test_config: Test configuration object
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+    test_config.args.seed = False
+
+    call_count = 0
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> None:
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible("2.15.0")
+
+    # Should not call get_dependency_constraint if seed is False
+    assert call_count == 0
+
+
+def test_no_warning_when_constraint_not_found(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that no warning is issued when constraint cannot be determined.
+
+    When the dependency constraint lookup returns None (e.g., package not found,
+    network issues), the warning should be skipped gracefully.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible("2.15.0")
+
+    # Should not have any warning messages
+    assert not any("ansible-dev-tools requires" in record.message for record in caplog.records)
+
+
+def test_warning_issued_for_incompatible_version(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that warning is issued when version is incompatible.
+
+    When the user requests an ansible-core version that falls outside
+    the requirements of ansible-dev-tools, a warning should be displayed.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> str:
+        return ">=2.16.0"
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible("2.15.0")
+
+    # Check that warning was logged
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warning_records) == 1
+    warning_msg = warning_records[0].message
+    assert "ansible-dev-tools requires ansible-core>=2.16.0" in warning_msg
+    assert "the requested version 2.15.0 falls outside this range" in warning_msg
+    assert "There may be compatibility issues" in warning_msg
+
+
+def test_no_warning_for_compatible_version(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that no warning is issued when version is compatible.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> str:
+        return ">=2.16.0"
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible("2.16.0")
+
+    # Should not have any warning messages
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warning_records) == 0
+
+
+def test_no_warning_for_higher_compatible_version(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that no warning is issued when version is higher than required.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> str:
+        return ">=2.16.0"
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible("2.19.0")
+
+    # Should not have any warning messages for higher compatible version
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warning_records) == 0
+
+
+def test_handles_packaging_import_error(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that function handles packaging module being unavailable gracefully.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> str:
+        return ">=2.16.0"
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+    # Mock the module-level variables to simulate packaging not being available
+    monkeypatch.setattr("ansible_dev_environment.subcommands.installer.specifiers", None)
+    monkeypatch.setattr("ansible_dev_environment.subcommands.installer.version", None)
+
+    installer._warn_if_core_version_incompatible("2.15.0")
+
+    # Should not have any warning messages when packaging is unavailable
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warning_records) == 0
+
+
+def test_handles_version_parsing_error(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that function handles version parsing errors gracefully.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> str:
+        return ">=2.16.0"
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    # Use a truly malformed version that will cause packaging.version.parse to fail
+    installer._warn_if_core_version_incompatible("invalid.version.string!")
+
+    # Should not have any warning messages when version parsing fails
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warning_records) == 0
+
+
+@pytest.mark.parametrize(
+    "pip_command",
+    (
+        "pip",
+        "uv pip",
+        "/path/to/pip",
+        "python -m pip",
+    ),
+)
+def test_uses_pip_command_correctly(
+    installer: Installer,
+    test_config: FakeConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    pip_command: str,
+) -> None:
+    """Test that pip command is used correctly from config.
+
+    Verifies that the installer passes the correct pip command from the
+    configuration to the dependency constraint lookup function.
+
+    Args:
+        installer: Installer instance under test
+        test_config: Test configuration object
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        pip_command: The pip command to test (parametrized)
+    """
+    test_config.venv_pip_cmd = pip_command
+
+    received_calls = []
+
+    def _get_dependency_constraint(
+        package_name: str,
+        dependency_name: str,
+        pip_command: str = "pip",
+        _timeout: int = 30,
+    ) -> str | None:
+        received_calls.append(
+            {
+                "package_name": package_name,
+                "dependency_name": dependency_name,
+                "pip_command": pip_command,
+            },
+        )
+        return None
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible("2.15.0")
+
+    assert len(received_calls) == 1
+    call = received_calls[0]
+    assert call["package_name"] == "ansible-dev-tools"
+    assert call["dependency_name"] == "ansible-core"
+    assert call["pip_command"] == pip_command
+
+
+def test_warning_called_from_install_ade_deps(
+    installer: Installer,
+    test_config: FakeConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that warning is called from _install_ade_deps when appropriate.
+
+    Verifies that the warning method is called with the correct version
+    when both a core version is specified and seed is True.
+
+    Args:
+        installer: Installer instance under test
+        test_config: Test configuration object
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+    test_config.args.ansible_core_version = "2.15.0"
+    test_config.args.seed = True
+
+    warning_calls: list[str] = []
+
+    def _warn_if_core_version_incompatible(version: str) -> None:
+        warning_calls.append(version)
+
+    def _install_dev_tools() -> None:
+        pass
+
+    def _install_core() -> None:
+        pass
+
+    monkeypatch.setattr(
+        installer,
+        "_warn_if_core_version_incompatible",
+        _warn_if_core_version_incompatible,
+    )
+    monkeypatch.setattr(installer, "_install_dev_tools", _install_dev_tools)
+    monkeypatch.setattr(installer, "_install_core", _install_core)
+
+    installer._install_ade_deps()
+
+    assert len(warning_calls) == 1
+    assert warning_calls[0] == "2.15.0"
+
+
+def test_warning_not_called_when_no_core_version(
+    installer: Installer,
+    test_config: FakeConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that warning is not called when no core version is specified.
+
+    When ansible_core_version is None, no version compatibility check
+    should be performed, even if seed is True.
+
+    Args:
+        installer: Installer instance under test
+        test_config: Test configuration object
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+    test_config.args.ansible_core_version = None
+    test_config.args.seed = True
+
+    warning_calls: list[str] = []
+
+    def _warn_if_core_version_incompatible(version: str) -> None:
+        warning_calls.append(version)
+
+    def _install_dev_tools() -> None:
+        pass
+
+    def _install_core() -> None:
+        pass
+
+    monkeypatch.setattr(
+        installer,
+        "_warn_if_core_version_incompatible",
+        _warn_if_core_version_incompatible,
+    )
+    monkeypatch.setattr(installer, "_install_dev_tools", _install_dev_tools)
+    monkeypatch.setattr(installer, "_install_core", _install_core)
+
+    installer._install_ade_deps()
+
+    assert len(warning_calls) == 0
+
+
+def test_warning_not_called_when_seed_false(
+    installer: Installer,
+    test_config: FakeConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that warning is not called when seed is False.
+
+    When seed is False, ansible-dev-tools won't be installed, so there's
+    no need to check for version compatibility warnings.
+
+    Args:
+        installer: Installer instance under test
+        test_config: Test configuration object
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+    test_config.args.ansible_core_version = "2.15.0"
+    test_config.args.seed = False
+
+    warning_calls: list[str] = []
+
+    def _warn_if_core_version_incompatible(version: str) -> None:
+        warning_calls.append(version)
+
+    def _install_dev_tools() -> None:
+        pass
+
+    def _install_core() -> None:
+        pass
+
+    monkeypatch.setattr(
+        installer,
+        "_warn_if_core_version_incompatible",
+        _warn_if_core_version_incompatible,
+    )
+    monkeypatch.setattr(installer, "_install_dev_tools", _install_dev_tools)
+    monkeypatch.setattr(installer, "_install_core", _install_core)
+
+    installer._install_ade_deps()
+
+    assert len(warning_calls) == 0
+
+
+@pytest.mark.parametrize(
+    ("constraint", "version", "should_warn"),
+    (
+        (">=2.16.0", "2.15.0", True),  # Should warn
+        (">=2.16.0", "2.16.0", False),  # Should not warn
+        (">=2.16.0", "2.17.0", False),  # Should not warn
+        (">2.16.0", "2.16.0", True),  # Should warn (strictly greater)
+        ("==2.16.0", "2.15.0", True),  # Should warn
+        ("==2.16.0", "2.16.0", False),  # Should not warn
+        ("~=2.16.0", "2.15.0", True),  # Should warn
+        ("~=2.16.0", "2.16.5", False),  # Should not warn
+    ),
+)
+def test_handles_different_constraint_formats(
+    installer: Installer,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    constraint: str,
+    version: str,
+    *,
+    should_warn: bool,
+) -> None:
+    """Test that different constraint formats are handled correctly.
+
+    Args:
+        installer: Installer instance under test
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        caplog: Pytest log capture fixture
+        constraint: The version constraint to test (parametrized)
+        version: The version to test against constraint (parametrized)
+        should_warn: Whether a warning should be issued (parametrized)
+    """
+
+    def _get_dependency_constraint(*_args: str, **_kwargs: str) -> str:
+        return constraint
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    installer._warn_if_core_version_incompatible(version)
+
+    warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+    if should_warn:
+        assert len(warning_records) == 1
+    else:
+        assert len(warning_records) == 0
+
+
+def test_integration_with_real_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test integration with a real config object.
+
+    This integration test verifies that the warning system works correctly
+    when using real Output objects instead of test fakes.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+    # This test uses real objects to ensure integration works
+
+    # Create real objects
+    term_features = TermFeatures(color=False, links=False)
+    output = Output(
+        log_file=str(tmp_path / "test.log"),
+        log_level="INFO",
+        log_append="false",
+        term_features=term_features,
+        verbosity=0,
+    )
+
+    # Test config with required attributes
+    config = FakeConfig()
+    config.venv_pip_cmd = "pip"
+    config.venv_pip_install_cmd = "pip install"
+    config.args.seed = True
+    config.args.ansible_core_version = "2.15.0"
+
+    installer = Installer(config=config, output=output)
+
+    # Verify the dependency constraint function is called
+    constraint_calls = []
+
+    def _get_dependency_constraint(
+        package_name: str,
+        dependency_name: str,
+        pip_command: str = "pip",
+        _timeout: int = 30,
+    ) -> str:
+        constraint_calls.append(
+            {
+                "package_name": package_name,
+                "dependency_name": dependency_name,
+                "pip_command": pip_command,
+            },
+        )
+        return ">=2.16.0"
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.get_dependency_constraint",
+        _get_dependency_constraint,
+    )
+
+    # This should not raise any exceptions
+    installer._warn_if_core_version_incompatible("2.15.0")
+
+    # Verify the constraint check was called
+    assert len(constraint_calls) == 1
+    call = constraint_calls[0]
+    assert call["package_name"] == "ansible-dev-tools"
+    assert call["dependency_name"] == "ansible-core"
+    assert call["pip_command"] == "pip"

--- a/tests/unit/test_installer_warning.py
+++ b/tests/unit/test_installer_warning.py
@@ -21,14 +21,15 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from ansible_dev_environment.output import Output
+from ansible_dev_environment.subcommands.installer import Installer
+from ansible_dev_environment.utils import TermFeatures
+
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-from ansible_dev_environment.config import Config
-from ansible_dev_environment.output import Output
-from ansible_dev_environment.subcommands.installer import Installer
-from ansible_dev_environment.utils import TermFeatures
+    from ansible_dev_environment.config import Config
 
 
 class FakeArgs:

--- a/tests/unit/test_utils_dependency_constraint.py
+++ b/tests/unit/test_utils_dependency_constraint.py
@@ -1,0 +1,442 @@
+"""Tests for get_dependency_constraint utility function.
+
+This module tests the get_dependency_constraint function in utils.py that dynamically
+determines package dependency constraints using pip's --dry-run functionality.
+
+The function uses subprocess to run pip commands and parses the output to extract
+version constraints for specific dependencies. These tests verify the parsing logic,
+error handling, and integration with different pip output formats.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from typing import NoReturn
+
+import pytest
+
+from ansible_dev_environment.utils import get_dependency_constraint
+
+
+# Constants for testing
+CUSTOM_TIMEOUT = 60
+
+
+def test_returns_none_for_nonexistent_package() -> None:
+    """Test that function returns None for packages that don't exist.
+
+    When pip cannot find a package, the function should gracefully return None
+    rather than raising an exception.
+    """
+    result = get_dependency_constraint(
+        package_name="definitely-does-not-exist-package-12345",
+        dependency_name="some-dependency",
+    )
+    assert result is None
+
+
+def test_returns_none_for_nonexistent_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that function returns None when dependency doesn't exist.
+
+    When the target package exists but doesn't depend on the specified dependency,
+    the function should return None.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "Would install some-other-package>=1.0.0"
+            self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="some-package",
+        dependency_name="nonexistent-dependency",
+    )
+    assert result is None
+
+
+def test_parses_standard_constraint_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing standard constraint format like 'package>=1.2.3'.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "Would install ansible-core>=2.16.0 other-package>=1.0.0"
+            self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+    )
+    assert result == ">=2.16.0"
+
+
+@pytest.mark.parametrize(
+    "output_format",
+    (
+        "Would install (ansible-core>=2.16.0) other-package",
+        "Requirement already satisfied: ansible-core>=2.16.0 in /path/to/site-packages",
+        "Dependencies: ansible-core (>=2.16.0), other-dep (>=1.0)",
+        "Would install ANSIBLE-CORE>=2.16.0",  # Case insensitive
+        "Some output without our dependency\nansible-core>=2.16.0 found in stderr",
+    ),
+)
+def test_parses_various_output_formats(
+    monkeypatch: pytest.MonkeyPatch,
+    output_format: str,
+) -> None:
+    """Test parsing various pip output formats.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        output_format: The output format to test (parametrized)
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            if "stderr" in output_format:
+                self.stdout, self.stderr = output_format.split("\n")
+            else:
+                self.stdout = output_format
+                self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+    )
+    assert result == ">=2.16.0"
+
+
+@pytest.mark.parametrize(
+    ("constraint_output", "expected"),
+    (
+        ("ansible-core>=2.16.0", ">=2.16.0"),
+        ("ansible-core>2.16.0", ">2.16.0"),
+        ("ansible-core==2.16.0", "==2.16.0"),
+        ("ansible-core~=2.16.0", "~=2.16.0"),
+        ("ansible-core!=2.15.0", "!=2.15.0"),
+        ("ansible-core<=2.17.0", "<=2.17.0"),
+    ),
+)
+def test_handles_different_constraint_operators(
+    monkeypatch: pytest.MonkeyPatch,
+    constraint_output: str,
+    expected: str,
+) -> None:
+    """Test that different constraint operators are parsed correctly.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        constraint_output: The constraint string in pip output (parametrized)
+        expected: The expected parsed constraint (parametrized)
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = f"Would install {constraint_output}"
+            self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("version_output", "expected"),
+    (
+        ("ansible-core>=2.16.0", ">=2.16.0"),
+        ("ansible-core>=2.16.0.1", ">=2.16.0.1"),
+        ("ansible-core>=2.16.0.2.3", ">=2.16.0.2.3"),
+    ),
+)
+def test_handles_complex_version_numbers(
+    monkeypatch: pytest.MonkeyPatch,
+    version_output: str,
+    expected: str,
+) -> None:
+    """Test that complex version numbers are parsed correctly.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+        version_output: The version string in pip output (parametrized)
+        expected: The expected parsed constraint (parametrized)
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = f"Would install {version_output}"
+            self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+    )
+    assert result == expected
+
+
+def test_handles_special_characters_in_package_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that package names with special characters are handled correctly.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "Would install some-package.with.dots>=1.0.0"
+            self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="some-package",
+        dependency_name="some-package.with.dots",
+    )
+    assert result == ">=1.0.0"
+
+
+def test_returns_none_on_pip_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that function returns None when pip command fails.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 1
+            self.stdout = ""
+            self.stderr = "ERROR: Could not find a version that satisfies the requirement"
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="nonexistent-package",
+        dependency_name="some-dependency",
+        timeout=1,
+    )
+    assert result is None
+
+
+def test_returns_none_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that function returns None when pip command times out.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    def _run(*_args: object, **_kwargs: object) -> NoReturn:
+        cmd = "pip"
+        timeout = 30
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="some-package",
+        dependency_name="some-dependency",
+        timeout=1,
+    )
+    assert result is None
+
+
+def test_returns_none_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that function returns None when any exception occurs.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    def _run(*_args: object, **_kwargs: object) -> NoReturn:
+        msg = "Unexpected error"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="some-package",
+        dependency_name="some-dependency",
+    )
+    assert result is None
+
+
+def test_uses_custom_pip_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that custom pip command is used correctly.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "Would install ansible-core>=2.16.0"
+            self.stderr = ""
+
+    received_commands: list[str] = []
+
+    def _run(command: str, *_args: object, **_kwargs: object) -> SubprocessResult:
+        received_commands.append(command)
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+        pip_command="uv pip",
+    )
+
+    assert len(received_commands) == 1
+    assert "uv pip install --dry-run ansible-dev-tools" in received_commands[0]
+
+
+def test_uses_custom_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that custom timeout is passed to subprocess.run.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "Would install ansible-core>=2.16.0"
+            self.stderr = ""
+
+    def _run(*_args: object, **kwargs: object) -> SubprocessResult:
+        # Verify timeout was passed correctly
+        assert kwargs.get("timeout") == CUSTOM_TIMEOUT
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+        timeout=CUSTOM_TIMEOUT,
+    )
+
+
+def test_finds_first_matching_pattern(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that function returns the first matching constraint found.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture for mocking
+    """
+
+    class SubprocessResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "ansible-core>=2.16.0 and also ansible-core>=2.15.0"
+            self.stderr = ""
+
+    def _run(*_args: object, **_kwargs: object) -> SubprocessResult:
+        return SubprocessResult()
+
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+    )
+
+    # Should return the first match
+    assert result == ">=2.16.0"
+
+
+def test_real_ansible_dev_tools_constraint() -> None:
+    """Test with real ansible-dev-tools package (if available).
+
+    This integration test will only work if pip is available and can reach PyPI.
+    If the package is not available or network is unreachable, it should return None.
+    """
+    result = get_dependency_constraint(
+        package_name="ansible-dev-tools",
+        dependency_name="ansible-core",
+        timeout=5,  # Short timeout for CI environments
+    )
+
+    # Should either find a constraint or return None (if package not available)
+    if result is not None:
+        # If we get a result, it should be a valid constraint string
+        assert any(op in result for op in [">=", ">", "==", "~=", "!=", "<=", "<"])
+        assert any(c.isdigit() for c in result)  # Should contain version numbers
+
+
+def test_real_pytest_constraint() -> None:
+    """Test with real pytest package (if available).
+
+    This tests the function with a package that's likely to be available
+    in the test environment.
+    """
+    result = get_dependency_constraint(
+        package_name="pytest",
+        dependency_name="packaging",  # pytest depends on packaging
+        timeout=5,
+    )
+
+    # Should either find a constraint or return None
+    if result is not None:
+        assert any(op in result for op in [">=", ">", "==", "~=", "!=", "<=", "<"])
+
+
+def test_timeout_with_slow_command() -> None:
+    """Test that timeout works with a slow command.
+
+    This test uses a command that will likely timeout to verify
+    the timeout functionality works correctly.
+    """
+    result = get_dependency_constraint(
+        package_name="some-nonexistent-package-that-will-be-slow",
+        dependency_name="some-dependency",
+        timeout=0.1,  # Very short timeout
+    )
+
+    # Should return None due to timeout
+    assert result is None

--- a/tests/unit/test_utils_dependency_constraint.py
+++ b/tests/unit/test_utils_dependency_constraint.py
@@ -435,7 +435,7 @@ def test_timeout_with_slow_command() -> None:
     result = get_dependency_constraint(
         package_name="some-nonexistent-package-that-will-be-slow",
         dependency_name="some-dependency",
-        timeout=0.1,  # Very short timeout
+        timeout=1,  # Very short timeout
     )
 
     # Should return None due to timeout


### PR DESCRIPTION
Fixes: #354 

## Problem

When users specify a specific ansible-core version via `--ansible-core-version`, the subsequent installation of ansible-dev-tools would override the user-specified version due to dependency resolution conflicts. For example, `ansible-core==2.16.0` would be upgraded to `ansible-core==2.19.0` during ansible-dev-tools installation.

## Solution

This PR implements a dependency-aware installation strategy that preserves user-specified ansible-core versions while providing compatibility warnings:

### Core Changes

1. **Installation Order**: Reorder dependency installation to install ansible-dev-tools first, then force-reinstall the user-specified ansible-core version
2. **Dynamic Dependency Detection**: Add `get_dependency_constraint()` utility that uses `pip install --dry-run` to determine ansible-dev-tools' ansible-core requirements at runtime  
3. **Compatibility Warnings**: Implement proactive warning system when user-requested versions fall outside ansible-dev-tools compatibility bounds
4. **Configuration Refactor**: Split `venv_pip_install_cmd` into separate `venv_pip_cmd` and `venv_pip_install_cmd` properties following DRY principles

### Implementation Details

- Leverages pip's native dependency resolution instead of hardcoded version constraints
- Uses subprocess with timeout and robust error handling for external pip commands
- Implements packaging library integration with graceful fallback when unavailable
- Adds comprehensive test suite with 50+ test cases covering edge cases and error scenarios

### Testing

- New integration test validates core version preservation
- Unit tests cover dependency constraint detection, warning logic, and error handling
- All existing tests pass, maintaining backward compatibility

## Technical Notes

The solution respects pip's dependency resolution while ensuring user intent is preserved. The warning system helps users understand potential compatibility issues without blocking installation.

Files changed: 5 files, 1215 insertions, 8 deletions