### PR TITLE
Pin tox workflow to circumvent issue with setup-uv and macOS/Python3.10

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   tox:
-    uses: ansible/team-devtools/.github/workflows/tox.yml@main
+    uses: ansible/team-devtools/.github/workflows/tox.yml@d894908cc9005130104c9807b460453c7c2bb398 # pinned due to issue with setup-uv
     with:
       max_python: "3.13"
       jobs_producing_coverage: 8


### PR DESCRIPTION
Pins the workflow to team-devtools main commit `d894908cc9005130104c9807b460453c7c2bb398` to circumvent issue with next commit that changes to use astral-uv instead of setup-python action. 

Something in the uv setup is causing macOS with Python 3.10 to hang indefinitely.