### PR TITLE
fix: auto-populate build_ignore in galaxy.yml during editable install

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -22,6 +22,7 @@ delenv
 excinfo
 fileh
 fqcn
+keepends
 netcommon
 platinclude
 platlib

--- a/src/ansible_dev_environment/collection.py
+++ b/src/ansible_dev_environment/collection.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from .constants import GALAXY_YAML
+
 
 if TYPE_CHECKING:
     from .config import Config
@@ -314,7 +316,7 @@ def get_galaxy(collection: Collection, output: Output) -> None:
     Raises:
         SystemExit: If the collection name is not found
     """
-    file_name = collection.path / "galaxy.yml"
+    file_name = collection.path / GALAXY_YAML
     if not file_name.exists():
         err = f"Failed to find {file_name} in {collection.path}"
         output.critical(err)

--- a/src/ansible_dev_environment/constants.py
+++ b/src/ansible_dev_environment/constants.py
@@ -1,0 +1,6 @@
+"""Constants for ansible-dev-environment."""
+
+from __future__ import annotations
+
+
+GALAXY_YAML = "galaxy.yml"

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -11,6 +11,8 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 
 try:
     from packaging import specifiers, version
@@ -19,6 +21,7 @@ except ImportError:
     version = None  # type: ignore[assignment]
 
 from ansible_dev_environment.collection import Collection, parse_collection_request
+from ansible_dev_environment.constants import GALAXY_YAML
 from ansible_dev_environment.utils import (
     builder_introspect,
     collections_from_requirements,
@@ -131,6 +134,7 @@ class Installer:
                 self._install_local_collection(collection=local_collection)
                 if self._config.args.editable:
                     self._swap_editable_collection(collection=local_collection)
+                    self._ensure_build_ignore(collection=local_collection)
             distant_collections = [collection for collection in collections if not collection.local]
             if distant_collections:
                 if self._config.args.editable:
@@ -604,8 +608,8 @@ class Installer:
         # preserve the MANIFEST.json file for editable installs
         if not self._config.args.editable:
             shutil.copy(
-                collection.build_dir / "galaxy.yml",
-                collection.site_pkg_path / "galaxy.yml",
+                collection.build_dir / GALAXY_YAML,
+                collection.site_pkg_path / GALAXY_YAML,
             )
         else:
             shutil.copy(
@@ -658,6 +662,60 @@ class Installer:
             "Note: If you add new root-level directories or files to your collection, "
             "you will need to re-run 'ade install -e .' to include them in the editable install."
         )
+        self._output.note(msg)
+
+    def _ensure_build_ignore(self, collection: Collection) -> None:
+        """Ensure galaxy.yml build_ignore includes dev artifacts created by editable installs.
+
+        Args:
+            collection: The collection object.
+        """
+        galaxy_file = collection.path / GALAXY_YAML
+        if not galaxy_file.exists():
+            return
+
+        content = galaxy_file.read_text(encoding="utf-8")
+
+        with galaxy_file.open(encoding="utf-8") as fh:
+            try:
+                galaxy_data = yaml.safe_load(fh)
+            except yaml.YAMLError:
+                msg = f"Failed to parse {galaxy_file}, skipping build_ignore update."
+                self._output.warning(msg)
+                return
+
+        if galaxy_data is None:
+            return
+
+        existing = set(galaxy_data.get("build_ignore") or [])
+        entries_to_add = [e for e in (".venv", "collections", ".tox") if e not in existing]
+
+        if not entries_to_add:
+            return
+
+        lines = content.splitlines(keepends=True)
+        insert_idx = None
+        indent = "  "
+
+        for i, line in enumerate(lines):
+            stripped = line.lstrip()
+            if stripped.startswith("- ") and insert_idx is not None:
+                indent = line[: len(line) - len(stripped)]
+                insert_idx = i + 1
+            elif stripped.startswith("build_ignore:"):
+                insert_idx = i + 1
+
+        if insert_idx is None:
+            lines.append("\nbuild_ignore:\n")
+            insert_idx = len(lines)
+            indent = "  "
+
+        new_lines = [f"{indent}- {entry}\n" for entry in entries_to_add]
+        lines[insert_idx:insert_idx] = new_lines
+
+        galaxy_file.write_text("".join(lines), encoding="utf-8")
+
+        msg = f"Added {', '.join(entries_to_add)} to build_ignore in galaxy.yml."
         self._output.note(msg)
 
     def _get_root_items_to_symlink(self, collection: Collection) -> set[str]:

--- a/src/ansible_dev_environment/utils.py
+++ b/src/ansible_dev_environment/utils.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 import subprocess_tee
 import yaml
 
+from ansible_dev_environment.constants import GALAXY_YAML
+
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -395,8 +397,8 @@ def collections_meta(config: Config) -> dict[str, dict[str, Any]]:
                 file = some_info_dirs[0] / "GALAXY.yml"
                 editable_location = ""
 
-            elif (name_dir / "galaxy.yml").exists():
-                file = name_dir / "galaxy.yml"
+            elif (name_dir / GALAXY_YAML).exists():
+                file = name_dir / GALAXY_YAML
                 editable_location = str(name_dir.resolve()) if name_dir.is_symlink() else ""
 
             if file:

--- a/tests/unit/test_installer_editable.py
+++ b/tests/unit/test_installer_editable.py
@@ -7,7 +7,10 @@ import subprocess
 
 from typing import TYPE_CHECKING
 
+import yaml
+
 from ansible_dev_environment.arg_parser import parse
+from ansible_dev_environment.collection import Collection
 from ansible_dev_environment.config import Config
 from ansible_dev_environment.subcommands.installer import Installer
 
@@ -17,7 +20,6 @@ if TYPE_CHECKING:
 
     import pytest
 
-    from ansible_dev_environment.collection import Collection
     from ansible_dev_environment.output import Output
 
 
@@ -379,3 +381,288 @@ def test_editable_skips_nonexistent_source_items(
     assert (collection_site_pkg / "galaxy.yml").exists()
     assert (collection_site_pkg / "galaxy.yml").is_symlink()
     assert not (collection_site_pkg / "plugins").exists()
+
+
+def test_editable_adds_build_ignore_entries(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> None:
+    """Test that editable install adds .venv, collections, .tox to build_ignore.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+    """
+    galaxy_file = installable_local_collection / "galaxy.yml"
+    galaxy_data = yaml.safe_load(galaxy_file.read_text())
+    galaxy_data["build_ignore"] = [".gitignore"]
+    yaml.dump(galaxy_data, galaxy_file.open("w"))
+
+    venv_path = tmp_path / "venv"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "--editable",
+            str(installable_local_collection),
+            "--venv",
+            str(venv_path),
+            "-vvv",
+        ],
+    )
+    args = parse()
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+    installer = Installer(config=config, output=config._output)
+    installer.run()
+
+    updated = yaml.safe_load(galaxy_file.read_text())
+    build_ignore = updated.get("build_ignore", [])
+    assert ".venv" in build_ignore
+    assert "collections" in build_ignore
+    assert ".tox" in build_ignore
+    assert ".gitignore" in build_ignore
+
+
+def test_editable_build_ignore_idempotent(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> None:
+    """Test that running editable install twice does not duplicate build_ignore entries.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+    """
+    galaxy_file = installable_local_collection / "galaxy.yml"
+    galaxy_data = yaml.safe_load(galaxy_file.read_text())
+    galaxy_data["build_ignore"] = [".gitignore", ".venv", "collections", ".tox"]
+    yaml.dump(galaxy_data, galaxy_file.open("w"))
+
+    original_content = galaxy_file.read_text()
+
+    venv_path = tmp_path / "venv"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "--editable",
+            str(installable_local_collection),
+            "--venv",
+            str(venv_path),
+            "-vvv",
+        ],
+    )
+    args = parse()
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+    installer = Installer(config=config, output=config._output)
+    installer.run()
+
+    assert galaxy_file.read_text() == original_content
+
+
+def test_editable_build_ignore_no_existing_section(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> None:
+    """Test that build_ignore section is created when it does not exist.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+    """
+    galaxy_file = installable_local_collection / "galaxy.yml"
+    galaxy_data = yaml.safe_load(galaxy_file.read_text())
+    galaxy_data.pop("build_ignore", None)
+    yaml.dump(galaxy_data, galaxy_file.open("w"))
+
+    venv_path = tmp_path / "venv"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "--editable",
+            str(installable_local_collection),
+            "--venv",
+            str(venv_path),
+            "-vvv",
+        ],
+    )
+    args = parse()
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+    installer = Installer(config=config, output=config._output)
+    installer.run()
+
+    updated = yaml.safe_load(galaxy_file.read_text())
+    build_ignore = updated.get("build_ignore", [])
+    assert ".venv" in build_ignore
+    assert "collections" in build_ignore
+    assert ".tox" in build_ignore
+
+
+def _make_installer(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> Installer:
+    """Create an Installer instance after a successful run.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+
+    Returns:
+        A configured Installer instance.
+    """
+    venv_path = tmp_path / "venv"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "--editable",
+            str(installable_local_collection),
+            "--venv",
+            str(venv_path),
+            "-vvv",
+        ],
+    )
+    args = parse()
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+    installer = Installer(config=config, output=config._output)
+    installer.run()
+    return installer
+
+
+def _make_mock_collection(
+    config: Config,
+    installable_local_collection: Path,
+) -> Collection:
+    """Create a mock Collection pointing at the test collection path.
+
+    Args:
+        config: The configuration object.
+        installable_local_collection: The collection path.
+
+    Returns:
+        A Collection object.
+    """
+    return Collection(
+        config=config,
+        path=installable_local_collection,
+        opt_deps="",
+        local=True,
+        cnamespace="ansible",
+        cname="posix",
+        csource=[],
+        specifier="",
+        original=".",
+    )
+
+
+def test_editable_build_ignore_skips_missing_galaxy(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> None:
+    """Test that _ensure_build_ignore skips when galaxy.yml does not exist.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+    """
+    installer = _make_installer(
+        tmp_path,
+        installable_local_collection,
+        monkeypatch,
+        output,
+    )
+    galaxy_file = installable_local_collection / "galaxy.yml"
+    galaxy_file.unlink()
+
+    mock_collection = _make_mock_collection(installer._config, installable_local_collection)
+    installer._ensure_build_ignore(collection=mock_collection)
+    assert not galaxy_file.exists()
+
+
+def test_editable_build_ignore_skips_invalid_yaml(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> None:
+    """Test that _ensure_build_ignore skips when galaxy.yml has invalid YAML.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+    """
+    installer = _make_installer(
+        tmp_path,
+        installable_local_collection,
+        monkeypatch,
+        output,
+    )
+    galaxy_file = installable_local_collection / "galaxy.yml"
+    galaxy_file.write_text(": [\ninvalid yaml\n")
+
+    mock_collection = _make_mock_collection(installer._config, installable_local_collection)
+    installer._ensure_build_ignore(collection=mock_collection)
+    assert galaxy_file.read_text() == ": [\ninvalid yaml\n"
+
+
+def test_editable_build_ignore_skips_empty_yaml(
+    tmp_path: Path,
+    installable_local_collection: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: Output,
+) -> None:
+    """Test that _ensure_build_ignore skips when galaxy.yml is empty.
+
+    Args:
+        tmp_path: A temporary directory.
+        installable_local_collection: The installable_local_collection fixture.
+        monkeypatch: The monkeypatch fixture.
+        output: The output fixture.
+    """
+    installer = _make_installer(
+        tmp_path,
+        installable_local_collection,
+        monkeypatch,
+        output,
+    )
+    galaxy_file = installable_local_collection / "galaxy.yml"
+    galaxy_file.write_text("")
+
+    mock_collection = _make_mock_collection(installer._config, installable_local_collection)
+    installer._ensure_build_ignore(collection=mock_collection)
+    assert galaxy_file.read_text() == ""


### PR DESCRIPTION
## Summary

Fixes https://github.com/ansible/ansible-dev-tools/issues/737

Running `ade install -e .` creates `.venv/`, `collections/`, and `.tox/` inside the collection root, but these aren't added to `build_ignore` in `galaxy.yml`. This causes `ansible-galaxy collection build` to bundle the entire virtual environment into the tarball — producing a ~63MB archive instead of ~30KB.

## What changed

Added `_ensure_build_ignore()` to the installer, called right after `_swap_editable_collection()` completes. It reads the existing `build_ignore` entries from `galaxy.yml` and appends `.venv`, `collections`, and `.tox` if they're not already present.

The method modifies the file by inserting lines at the correct position rather than dumping the full YAML, so existing comments and formatting in `galaxy.yml` are preserved.

## How I tested this

1. Created a fresh collection with `ansible-creator init collection`
2. Ran `ade install -e .` — confirmed `.venv`, `collections`, `.tox` were added to `build_ignore`
3. Ran `ansible-galaxy collection build` — tarball went from 63MB (7212 venv files) to 30KB (0 venv files)
4. Ran `ade install -e .` again — no duplicate entries added (idempotent)
5. Verified comments in `galaxy.yml` were preserved after the update