### PR TITLE
fix: detect editable installs via galaxy.yml symlink in lister

### DIFF
--- a/src/ansible_dev_environment/subcommands/lister.py
+++ b/src/ansible_dev_environment/subcommands/lister.py
@@ -67,8 +67,11 @@ class Lister:
             collection_path = (
                 self._config.site_pkg_collections_path / collection_namespace / collection_name
             )
+            collection_galaxy_path = collection_path / "galaxy.yml"
             if collection_path.is_symlink():
                 editable_location = str(collection_path.resolve())
+            elif collection_galaxy_path.is_symlink():
+                editable_location = str(collection_galaxy_path.resolve().parent)
             else:
                 editable_location = ""
 

--- a/tests/unit/test_lister.py
+++ b/tests/unit/test_lister.py
@@ -231,3 +231,70 @@ def test_editable(
     captured = capsys.readouterr()
     assert "ansible.posix" in captured.out
     assert str(tmp_path / "ansible.posix") in captured.out
+
+
+def test_editable_galaxy_yml_symlink(
+    tmp_path: Path,
+    output: Output,
+    galaxy_cache: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the lister detects editable installs via galaxy.yml symlink.
+
+    When a collection directory is not itself a symlink but contains a
+    symlinked galaxy.yml, the lister should resolve the symlink to find
+    the editable project location.
+
+    Args:
+        tmp_path: The tmp_path fixture.
+        output: The output fixture.
+        galaxy_cache: The galaxy_cache fixture.
+        capsys: The capsys fixture.
+        monkeypatch: The monkeypatch fixture.
+
+    """
+    src_dir = tmp_path / "ansible.posix"
+    tar_file_path = next(galaxy_cache.glob("ansible-posix*"))
+    with tarfile.open(tar_file_path, "r") as tar:
+        try:
+            tar.extractall(src_dir, filter="data")
+        except TypeError:
+            tar.extractall(src_dir)  # noqa: S202
+    galaxy_contents = {
+        "authors": "author",
+        "name": "posix",
+        "namespace": "ansible",
+        "readme": "readme",
+        "version": "1.0.0",
+    }
+    yaml.dump(galaxy_contents, (src_dir / "galaxy.yml").open("w"))
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ade",
+            "install",
+            "--editable",
+            str(src_dir),
+            "--lf",
+            str(tmp_path / "ade.log"),
+            "--venv",
+            str(tmp_path / "venv"),
+        ],
+    )
+    args = parse()
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.init()
+    installer = Installer(config=config, output=config._output)
+    installer.run()
+
+    collection_path = config.site_pkg_collections_path / "ansible" / "posix"
+    assert not collection_path.is_symlink(), "collection dir should not be a symlink"
+    assert (collection_path / "galaxy.yml").is_symlink(), "galaxy.yml should be a symlink"
+
+    lister = Lister(config=config, output=config._output)
+    lister.run()
+    captured = capsys.readouterr()
+    assert "ansible.posix" in captured.out
+    assert str(src_dir) in captured.out


### PR DESCRIPTION
## Summary

- Fix the lister to detect editable installs when the collection directory is not itself a symlink but `galaxy.yml` inside it is a symlink pointing to the source project
- The editable installer (`_swap_editable_collection`) now creates per-file symlinks rather than a single directory-level symlink, so the lister's existing `collection_path.is_symlink()` check no longer detects editable installs
- Add a dedicated test (`test_editable_galaxy_yml_symlink`) verifying the new detection path

Fixes #415

## Test plan

- [x] Existing `test_editable` continues to pass
- [x] New `test_editable_galaxy_yml_symlink` asserts that the collection directory is **not** a symlink, `galaxy.yml` **is** a symlink, and the lister correctly reports the resolved editable project location
- [x] All 6 lister tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)