### PR TITLE
fix: add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -10,6 +10,14 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
+# Explicit permissions required: CodeQL actions/missing-workflow-permissions.
+# Caller must grant at least what team-devtools ack.yml needs (checks, PR
+# approve/merge, and contents write for release-drafter autolabeler).
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,13 @@ on:
       - "stable/**"
   workflow_dispatch:
 
+# Explicit permissions required: CodeQL actions/missing-workflow-permissions.
+# Caller must grant at least what team-devtools push.yml needs (contents write
+# for release-drafter draft updates; pull-requests read for changelog input).
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/push.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
   forum_post:
     needs: release
     runs-on: ubuntu-24.04
+    # Explicit empty permissions: CodeQL actions/missing-workflow-permissions.
+    # Job only posts to the forum via secrets; it does not need GITHUB_TOKEN.
+    permissions: {}
 
     steps:
       - name: Retreive the forum post script from team-devtools


### PR DESCRIPTION
Resolve CodeQL actions/missing-workflow-permissions on ack, push, and release forum_post jobs by declaring least-privilege permissions.