### PR TITLE
fix: use greedy quantifier in galaxy installed regex (S8786)

### DIFF
--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -93,7 +93,7 @@ class Installer:
         RE_GALAXY_INSTALLED: The regular expression to match galaxy installed collections
     """
 
-    RE_GALAXY_INSTALLED = re.compile(r"(\w+\.\w+):[^\n]*?installed")
+    RE_GALAXY_INSTALLED = re.compile(r"(\w+\.\w+):[^\n]*installed")
 
     def __init__(self, config: Config, output: Output) -> None:
         """Initialize the installer.


### PR DESCRIPTION
Change lazy `[^\n]*?` to greedy `[^\n]*` to eliminate backtracking. Greedy is safe here because the character class excludes newlines and the literal `installed` that follows cannot match `[^\n]`.