### PR TITLE
fix: honor Automation Hub auth during local collection install

### DIFF
--- a/src/ansible_dev_environment/cli.py
+++ b/src/ansible_dev_environment/cli.py
@@ -36,7 +36,7 @@ class Cli:
         self.acfg_cwd = AnsibleCfg(path=Path("./ansible.cfg"))
         self.acfg_home = AnsibleCfg(path=Path("~/.ansible.cfg").expanduser().resolve())
         self.acfg_system = AnsibleCfg(path=Path("/etc/ansible/ansible.cfg"))
-        self.acfg_trusted: Path | None
+        self.acfg_trusted: Path | None = None
 
     def parse_args(self) -> None:
         """Parse the command line arguments."""
@@ -236,6 +236,7 @@ class Cli:
             term_features=self.term_features,
         )
         self.config.init()
+        self.config.ansible_cfg = self.acfg_trusted
 
         subcommand_cls = getattr(subcommands, self.config.args.subcommand.capitalize())
         subcommand = subcommand_cls(config=self.config, output=self.output)

--- a/src/ansible_dev_environment/config.py
+++ b/src/ansible_dev_environment/config.py
@@ -39,6 +39,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
         """
         self._create_venv: bool = False
         self.args: Namespace = args
+        self.ansible_cfg: Path | None = None
         self.bindir: Path
         self._output: Output = output
         self.python_path: Path

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -1,3 +1,4 @@
+# pylint: disable=C0302
 """The installer."""
 
 from __future__ import annotations
@@ -69,7 +70,7 @@ def _resolve_core_package(core_version: str) -> str:
     return f"{ANSIBLE_CORE_REPO_URL}/{core_version}.tar.gz"
 
 
-ACCESS_TOKEN_ERROR = "Unable to get access token"
+ACCESS_TOKEN_ERROR = "Unable to get access token"  # noqa: S105
 
 
 def format_process(exc: subprocess.CalledProcessError) -> str:
@@ -106,9 +107,9 @@ def galaxy_dependency_specs(dependencies: object) -> list[str]:
         if not name:
             continue
         spec = str(name)
-        version = "" if specifier is None else str(specifier).strip()
-        if version and version != "*":
-            spec = f"{spec}:{version}"
+        version_spec = "" if specifier is None else str(specifier).strip()
+        if version_spec and version_spec != "*":
+            spec = f"{spec}:{version_spec}"
         specs.append(spec)
     return specs
 
@@ -578,7 +579,7 @@ class Installer:
                 err = f"Failed to copy collection to build directory: {exc}"
                 self._output.critical(err)
 
-    def _install_local_collection(
+    def _install_local_collection(  # noqa: PLR0915
         self,
         collection: Collection,
     ) -> None:
@@ -744,7 +745,7 @@ class Installer:
         Raises:
             SystemError: If dependency installation fails.
         """
-        collections_str = " ".join(f"'{spec}'" for spec in dependency_specs)
+        collections_str = " ".join(shlex.quote(spec) for spec in dependency_specs)
         msg = f"Installing collection dependencies from galaxy.yml: {collections_str}"
         self._output.info(msg)
 

--- a/src/ansible_dev_environment/subcommands/installer.py
+++ b/src/ansible_dev_environment/subcommands/installer.py
@@ -69,6 +69,9 @@ def _resolve_core_package(core_version: str) -> str:
     return f"{ANSIBLE_CORE_REPO_URL}/{core_version}.tar.gz"
 
 
+ACCESS_TOKEN_ERROR = "Unable to get access token"
+
+
 def format_process(exc: subprocess.CalledProcessError) -> str:
     """Format the subprocess exception.
 
@@ -84,6 +87,30 @@ def format_process(exc: subprocess.CalledProcessError) -> str:
     if exc.stderr:
         result += f"stderr:\n{exc.stderr}"
     return result
+
+
+def galaxy_dependency_specs(dependencies: object) -> list[str]:
+    """Convert galaxy.yml dependencies to ansible-galaxy collection specs.
+
+    Args:
+        dependencies: The dependencies mapping from galaxy.yml.
+
+    Returns:
+        A list of collection specs suitable for ansible-galaxy install.
+    """
+    if not isinstance(dependencies, dict):
+        return []
+
+    specs: list[str] = []
+    for name, specifier in dependencies.items():
+        if not name:
+            continue
+        spec = str(name)
+        version = "" if specifier is None else str(specifier).strip()
+        if version and version != "*":
+            spec = f"{spec}:{version}"
+        specs.append(spec)
+    return specs
 
 
 class Installer:
@@ -105,6 +132,43 @@ class Installer:
         self._config = config
         self._output = output
         self._current_collection_spec: str
+
+    def _galaxy_env(self) -> dict[str, str]:
+        """Build environment variables for ansible-galaxy subprocesses.
+
+        Pins ANSIBLE_CONFIG to the trusted ansible.cfg from cfg isolation so
+        galaxy server and token settings match interactive ansible-galaxy use.
+
+        Returns:
+            Environment mapping for ansible-galaxy.
+        """
+        env = {
+            **os.environ,
+            "ANSIBLE_GALAXY_COLLECTIONS_PATH_WARNING": str(self._config.args.verbose),
+        }
+        if self._config.ansible_cfg is not None:
+            env["ANSIBLE_CONFIG"] = str(self._config.ansible_cfg)
+        return env
+
+    def _hint_galaxy_auth_failure(self, exc: subprocess.CalledProcessError) -> None:
+        """Emit a hint when ansible-galaxy fails Automation Hub token exchange.
+
+        Args:
+            exc: The failed ansible-galaxy subprocess exception.
+        """
+        stderr = exc.stderr or ""
+        if ACCESS_TOKEN_ERROR not in stderr:
+            return
+
+        hint = (
+            "Automation Hub authentication failed while talking to galaxy servers. "
+            "Ensure ansible.cfg [galaxy] server_list / [galaxy_server.*] names match "
+            "environment variables like ANSIBLE_GALAXY_SERVER_<SERVER>_TOKEN, and that "
+            "the value is a Red Hat offline token."
+        )
+        if self._config.ansible_cfg is not None:
+            hint += f" Using ANSIBLE_CONFIG={self._config.ansible_cfg}."
+        self._output.hint(hint)
 
     def run(self) -> None:
         """Run the installer."""
@@ -326,21 +390,18 @@ class Installer:
             f" -p {self._config.site_pkg_path}"
             " --force"
         )
-        env = {
-            **os.environ,
-            "ANSIBLE_GALAXY_COLLECTIONS_PATH_WARNING": str(self._config.args.verbose),
-        }
         msg = "Running ansible-galaxy to install non-local collection and it's dependencies."
         self._output.debug(msg)
         try:
             proc = subprocess_run(
                 command=command,
-                env=env,
+                env=self._galaxy_env(),
                 verbose=self._config.args.verbose,
                 msg=msg,
                 output=self._output,
             )
         except subprocess.CalledProcessError as exc:
+            self._hint_galaxy_auth_failure(exc)
             err = f"Failed to install collection: {format_process(exc)}"
             self._output.critical(err)
             raise SystemError(err) from exc  # pragma: no cover # critical exits
@@ -379,11 +440,13 @@ class Installer:
         try:
             proc = subprocess_run(
                 command=command,
+                env=self._galaxy_env(),
                 verbose=self._config.args.verbose,
                 msg=work,
                 output=self._output,
             )
         except subprocess.CalledProcessError as exc:
+            self._hint_galaxy_auth_failure(exc)
             err = f"Failed to install collections: {format_process(exc)}"
             self._output.critical(err)
 
@@ -590,26 +653,35 @@ class Installer:
             self._output.debug(msg)
             shutil.rmtree(info_dir)
 
+        dependency_specs = self._collection_dependency_specs(collection)
+        installed_names: list[str] = []
+        if dependency_specs:
+            installed_names.extend(
+                self._install_collection_dependencies(dependency_specs),
+            )
+
+        no_deps = " --no-deps" if dependency_specs else ""
         command = (
             f"{self._config.galaxy_bin} collection"
             f" install {tarball} -p {self._config.site_pkg_path}"
-            " --force"
+            f" --force{no_deps}"
         )
-        env = {
-            **os.environ,
-            "ANSIBLE_GALAXY_COLLECTIONS_PATH_WARNING": str(self._config.args.verbose),
-        }
-        msg = "Running ansible-galaxy to install a local collection and it's dependencies."
+        msg = (
+            "Running ansible-galaxy to install a local collection without dependencies."
+            if dependency_specs
+            else "Running ansible-galaxy to install a local collection and it's dependencies."
+        )
         self._output.debug(msg)
         try:
             proc = subprocess_run(
                 command=command,
-                env=env,
+                env=self._galaxy_env(),
                 verbose=self._config.args.verbose,
                 msg=msg,
                 output=self._output,
             )
         except subprocess.CalledProcessError as exc:
+            self._hint_galaxy_auth_failure(exc)
             err = f"Failed to install collection: {format_process(exc)}"
             self._output.critical(err)
             raise SystemError(err) from exc  # pragma: no cover # critical exits
@@ -628,9 +700,77 @@ class Installer:
                 collection.cache_dir / "MANIFEST.json",
             )
 
-        installed = self.RE_GALAXY_INSTALLED.findall(proc.stdout)
+        installed_names.extend(self.RE_GALAXY_INSTALLED.findall(proc.stdout))
+        # Preserve order while removing duplicates from dep + local install notes.
+        installed = list(dict.fromkeys(installed_names))
         msg = f"Installed collections include: {oxford_join(installed)}"
         self._output.note(msg)
+
+    def _collection_dependency_specs(self, collection: Collection) -> list[str]:
+        """Read collection dependency specs from galaxy.yml.
+
+        Args:
+            collection: The local collection being installed.
+
+        Returns:
+            ansible-galaxy collection specs for dependencies.
+        """
+        galaxy_file = collection.path / GALAXY_YAML
+        if not galaxy_file.exists():
+            return []
+
+        try:
+            with galaxy_file.open(encoding="utf-8") as fh:
+                galaxy_data = yaml.safe_load(fh) or {}
+        except yaml.YAMLError as exc:
+            msg = f"Failed to parse {galaxy_file} for dependencies: {exc}"
+            self._output.warning(msg)
+            return []
+
+        if not isinstance(galaxy_data, dict):
+            return []
+
+        return galaxy_dependency_specs(galaxy_data.get("dependencies"))
+
+    def _install_collection_dependencies(self, dependency_specs: list[str]) -> list[str]:
+        """Install galaxy.yml dependencies into the virtual environment.
+
+        Args:
+            dependency_specs: Collection specs to install.
+
+        Returns:
+            Names of collections reported as installed by ansible-galaxy.
+
+        Raises:
+            SystemError: If dependency installation fails.
+        """
+        collections_str = " ".join(f"'{spec}'" for spec in dependency_specs)
+        msg = f"Installing collection dependencies from galaxy.yml: {collections_str}"
+        self._output.info(msg)
+
+        command = (
+            f"{self._config.galaxy_bin} collection"
+            f" install {collections_str}"
+            f" -p {self._config.site_pkg_path}"
+            " --force"
+        )
+        work = "Running ansible-galaxy to install collection dependencies."
+        self._output.debug(work)
+        try:
+            proc = subprocess_run(
+                command=command,
+                env=self._galaxy_env(),
+                verbose=self._config.args.verbose,
+                msg=work,
+                output=self._output,
+            )
+        except subprocess.CalledProcessError as exc:
+            self._hint_galaxy_auth_failure(exc)
+            err = f"Failed to install collection dependencies: {format_process(exc)}"
+            self._output.critical(err)
+            raise SystemError(err) from exc  # pragma: no cover # critical exits
+
+        return self.RE_GALAXY_INSTALLED.findall(proc.stdout)
 
     def _swap_editable_collection(self, collection: Collection) -> None:
         """Swap the installed collection with selective symlinks.

--- a/tests/unit/test_installer_galaxy_auth.py
+++ b/tests/unit/test_installer_galaxy_auth.py
@@ -219,15 +219,13 @@ def test_local_install_installs_deps_then_uses_no_deps(
     installer._install_local_collection(collection)
 
     galaxy_calls = [c for c in calls if "ansible-galaxy" in c["command"]]
-    assert len(galaxy_calls) == 3
-
-    deps_call = galaxy_calls[1]
+    build_call, deps_call, local_call = galaxy_calls
+    assert "collection build" in build_call["command"]
     assert "install 'ansible.posix:>=1.0.0' 'redhat.openshift:>=4.0.2'" in deps_call["command"]
     assert f"-p {config.site_pkg_path}" in deps_call["command"]
     assert deps_call["env"]["ANSIBLE_CONFIG"] == str(cfg)
     assert "--no-deps" not in deps_call["command"]
 
-    local_call = galaxy_calls[2]
     assert str(collection.build_dir / "infra-demo-1.0.0.tar.gz") in local_call["command"]
     assert "--no-deps" in local_call["command"]
     assert local_call["env"]["ANSIBLE_CONFIG"] == str(cfg)

--- a/tests/unit/test_installer_galaxy_auth.py
+++ b/tests/unit/test_installer_galaxy_auth.py
@@ -1,0 +1,337 @@
+"""Tests for Automation Hub / galaxy.cfg handling during install (AAP-48435)."""
+
+from __future__ import annotations
+
+import subprocess
+
+from argparse import Namespace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from ansible_dev_environment.collection import Collection
+from ansible_dev_environment.config import Config
+from ansible_dev_environment.subcommands.installer import (
+    ACCESS_TOKEN_ERROR,
+    Installer,
+    galaxy_dependency_specs,
+)
+
+
+if TYPE_CHECKING:
+    from ansible_dev_environment.output import Output
+
+
+def _make_config(tmp_path: Path, output: Output, *, ansible_cfg: Path | None = None) -> Config:
+    """Build a Config with paths suitable for installer unit tests.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+        ansible_cfg: Optional trusted ansible.cfg path.
+
+    Returns:
+        Config instance with site packages and venv paths prepared.
+    """
+    venv = tmp_path / "venv"
+    site_pkg = venv / "lib" / "python3.13" / "site-packages"
+    site_pkg.mkdir(parents=True)
+    (site_pkg / "ansible_collections").mkdir()
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "ansible-galaxy").touch()
+
+    args = Namespace(
+        verbose=0,
+        venv=str(venv),
+        editable=False,
+        seed=False,
+        subcommand="install",
+        collection_specifier=None,
+        requirement=None,
+        cpi=False,
+        uv=False,
+    )
+    config = Config(args=args, output=output, term_features=output.term_features)
+    config.site_pkg_path = site_pkg
+    config.venv_interpreter = venv / "bin" / "python"
+    config.ansible_cfg = ansible_cfg
+    return config
+
+
+def _make_local_collection(
+    config: Config,
+    collection_path: Path,
+    *,
+    dependencies: dict[str, str] | None = None,
+) -> Collection:
+    """Create a local Collection with galaxy.yml and a fake built tarball.
+
+    Args:
+        config: Application config.
+        collection_path: Path for the local collection sources.
+        dependencies: Optional galaxy.yml dependencies mapping.
+
+    Returns:
+        Collection ready for _install_local_collection.
+    """
+    collection_path.mkdir(parents=True, exist_ok=True)
+    galaxy = {
+        "namespace": "infra",
+        "name": "demo",
+        "version": "1.0.0",
+        "readme": "README.md",
+        "authors": ["tester"],
+    }
+    if dependencies is not None:
+        galaxy["dependencies"] = dependencies
+    (collection_path / "galaxy.yml").write_text(yaml.dump(galaxy), encoding="utf-8")
+    (collection_path / "README.md").write_text("demo", encoding="utf-8")
+
+    collection = Collection(
+        config=config,
+        path=collection_path,
+        opt_deps="",
+        local=True,
+        cnamespace="infra",
+        cname="demo",
+        csource=[],
+        specifier="",
+        original=str(collection_path),
+    )
+    # Pre-create build dir artifacts so install does not need a real galaxy build/copy.
+    collection.build_dir.mkdir(parents=True, exist_ok=True)
+    (collection.build_dir / "infra-demo-1.0.0.tar.gz").write_text("fake", encoding="utf-8")
+    (collection.build_dir / "galaxy.yml").write_text(yaml.dump(galaxy), encoding="utf-8")
+    return collection
+
+
+def test_galaxy_dependency_specs() -> None:
+    """Test conversion of galaxy.yml dependencies to ansible-galaxy specs."""
+    assert galaxy_dependency_specs(None) == []
+    assert galaxy_dependency_specs("not-a-dict") == []
+    assert galaxy_dependency_specs({}) == []
+    assert galaxy_dependency_specs(
+        {
+            "ansible.posix": ">=1.0.0",
+            "kubernetes.core": "*",
+            "redhat.openshift": None,
+            "": "1.0.0",
+        },
+    ) == [
+        "ansible.posix:>=1.0.0",
+        "kubernetes.core",
+        "redhat.openshift",
+    ]
+
+
+def test_galaxy_env_includes_ansible_config(tmp_path: Path, output: Output) -> None:
+    """Trusted ansible.cfg is pinned into galaxy subprocess env."""
+    cfg = tmp_path / "ansible.cfg"
+    cfg.write_text("[defaults]\ncollections_path = .\n", encoding="utf-8")
+    config = _make_config(tmp_path, output, ansible_cfg=cfg)
+    installer = Installer(config=config, output=output)
+
+    env = installer._galaxy_env()
+    assert env["ANSIBLE_CONFIG"] == str(cfg)
+    assert env["ANSIBLE_GALAXY_COLLECTIONS_PATH_WARNING"] == "0"
+
+
+def test_galaxy_env_omits_ansible_config_when_unset(tmp_path: Path, output: Output) -> None:
+    """ANSIBLE_CONFIG is omitted when no trusted cfg was selected."""
+    config = _make_config(tmp_path, output, ansible_cfg=None)
+    installer = Installer(config=config, output=output)
+
+    env = installer._galaxy_env()
+    assert "ANSIBLE_CONFIG" not in env
+
+
+def test_local_install_preinstalls_deps_and_uses_no_deps(
+    tmp_path: Path,
+    output: Output,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local install installs galaxy.yml deps then the tarball with --no-deps."""
+    cfg = tmp_path / "ansible.cfg"
+    cfg.write_text("[defaults]\ncollections_path = .\n", encoding="utf-8")
+    config = _make_config(tmp_path, output, ansible_cfg=cfg)
+    collection = _make_local_collection(
+        config,
+        tmp_path / "infra.demo",
+        dependencies={
+            "ansible.posix": ">=1.0.0",
+            "redhat.openshift": ">=4.0.2",
+        },
+    )
+    installer = Installer(config=config, output=output)
+
+    calls: list[dict[str, Any]] = []
+
+    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(kwargs)
+        command = kwargs["command"]
+        if "collection build" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if "ansible.posix" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    "ansible.posix:1.0.0 was installed successfully\n"
+                    "redhat.openshift:4.0.2 was installed successfully\n"
+                ),
+                stderr="",
+            )
+        collection.site_pkg_path.mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="infra.demo:1.0.0 was installed successfully\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.subprocess_run",
+        mock_subprocess_run,
+    )
+    monkeypatch.setattr(installer, "_copy_repo_files", MagicMock())
+
+    installer._install_local_collection(collection)
+
+    galaxy_calls = [c for c in calls if "ansible-galaxy" in c["command"]]
+    assert len(galaxy_calls) == 3
+
+    deps_call = galaxy_calls[1]
+    assert "install 'ansible.posix:>=1.0.0' 'redhat.openshift:>=4.0.2'" in deps_call["command"]
+    assert f"-p {config.site_pkg_path}" in deps_call["command"]
+    assert deps_call["env"]["ANSIBLE_CONFIG"] == str(cfg)
+    assert "--no-deps" not in deps_call["command"]
+
+    local_call = galaxy_calls[2]
+    assert str(collection.build_dir / "infra-demo-1.0.0.tar.gz") in local_call["command"]
+    assert "--no-deps" in local_call["command"]
+    assert local_call["env"]["ANSIBLE_CONFIG"] == str(cfg)
+
+
+def test_local_install_without_deps_skips_no_deps(
+    tmp_path: Path,
+    output: Output,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local install without galaxy.yml deps does not use --no-deps."""
+    config = _make_config(tmp_path, output, ansible_cfg=None)
+    collection = _make_local_collection(
+        config,
+        tmp_path / "infra.demo",
+        dependencies={},
+    )
+    installer = Installer(config=config, output=output)
+
+    calls: list[dict[str, Any]] = []
+
+    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(kwargs)
+        if "collection install" in kwargs["command"]:
+            collection.site_pkg_path.mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(
+            kwargs["command"],
+            0,
+            stdout="infra.demo:1.0.0 was installed successfully\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.subprocess_run",
+        mock_subprocess_run,
+    )
+    monkeypatch.setattr(installer, "_copy_repo_files", MagicMock())
+
+    installer._install_local_collection(collection)
+
+    galaxy_installs = [
+        c
+        for c in calls
+        if "collection install" in c["command"] and "ansible-galaxy" in c["command"]
+    ]
+    assert len(galaxy_installs) == 1
+    assert "--no-deps" not in galaxy_installs[0]["command"]
+    assert "ANSIBLE_CONFIG" not in galaxy_installs[0]["env"]
+
+
+def test_auth_failure_emits_hint(
+    tmp_path: Path,
+    output: Output,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Access-token failures emit a hint about AH offline tokens and ANSIBLE_CONFIG."""
+    cfg = tmp_path / "ansible.cfg"
+    cfg.write_text("[defaults]\ncollections_path = .\n", encoding="utf-8")
+    config = _make_config(tmp_path, output, ansible_cfg=cfg)
+    collection = _make_local_collection(
+        config,
+        tmp_path / "infra.demo",
+        dependencies={"ansible.posix": ">=1.0.0"},
+    )
+    installer = Installer(config=config, output=output)
+
+    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+        command = kwargs["command"]
+        if "collection build" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            output="",
+            stderr=f"ERROR! {ACCESS_TOKEN_ERROR} (HTTP Code: 400, Message: Bad Request)\n",
+        )
+
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.subprocess_run",
+        mock_subprocess_run,
+    )
+    monkeypatch.setattr(installer, "_copy_repo_files", MagicMock())
+
+    with pytest.raises(SystemExit):
+        installer._install_local_collection(collection)
+
+    captured = capsys.readouterr()
+    assert "Automation Hub authentication failed" in captured.out + captured.err
+    assert "ANSIBLE_GALAXY_SERVER_<SERVER>_TOKEN" in captured.out + captured.err
+    assert f"ANSIBLE_CONFIG={cfg}" in captured.out + captured.err
+
+
+def test_cli_assigns_trusted_ansible_cfg(
+    tmp_path: Path,
+    output: Output,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cli.run copies acfg_trusted onto Config.ansible_cfg."""
+    from ansible_dev_environment.cli import Cli
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["ade", "install", "--no-seed", "--venv", str(tmp_path / "venv")],
+    )
+
+    cli = Cli()
+    cli.parse_args()
+    cli.output = output
+    cli.term_features = output.term_features
+    cli.args_sanity()
+    assert cli.isolation_check() is True
+    assert cli.acfg_trusted is not None
+
+    # Avoid running a full install; only exercise Config plumbing.
+    monkeypatch.setattr(
+        "ansible_dev_environment.subcommands.installer.Installer.run",
+        MagicMock(),
+    )
+    # Config.init creates a venv; let it run then stop before Installer work via mock above.
+    with pytest.raises(SystemExit) as exc:
+        cli.run()
+    assert exc.value.code == 0
+    assert cli.config.ansible_cfg == cli.acfg_trusted

--- a/tests/unit/test_installer_galaxy_auth.py
+++ b/tests/unit/test_installer_galaxy_auth.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import subprocess
 
 from argparse import Namespace
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
 import yaml
 
+from ansible_dev_environment.cli import Cli
 from ansible_dev_environment.collection import Collection
 from ansible_dev_environment.config import Config
 from ansible_dev_environment.subcommands.installer import (
@@ -22,6 +22,8 @@ from ansible_dev_environment.subcommands.installer import (
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ansible_dev_environment.output import Output
 
 
@@ -78,7 +80,7 @@ def _make_local_collection(
         Collection ready for _install_local_collection.
     """
     collection_path.mkdir(parents=True, exist_ok=True)
-    galaxy = {
+    galaxy: dict[str, object] = {
         "namespace": "infra",
         "name": "demo",
         "version": "1.0.0",
@@ -110,9 +112,9 @@ def _make_local_collection(
 
 def test_galaxy_dependency_specs() -> None:
     """Test conversion of galaxy.yml dependencies to ansible-galaxy specs."""
-    assert galaxy_dependency_specs(None) == []
-    assert galaxy_dependency_specs("not-a-dict") == []
-    assert galaxy_dependency_specs({}) == []
+    assert not galaxy_dependency_specs(None)
+    assert not galaxy_dependency_specs("not-a-dict")
+    assert not galaxy_dependency_specs({})
     assert galaxy_dependency_specs(
         {
             "ansible.posix": ">=1.0.0",
@@ -128,7 +130,12 @@ def test_galaxy_dependency_specs() -> None:
 
 
 def test_galaxy_env_includes_ansible_config(tmp_path: Path, output: Output) -> None:
-    """Trusted ansible.cfg is pinned into galaxy subprocess env."""
+    """Trusted ansible.cfg is pinned into galaxy subprocess env.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+    """
     cfg = tmp_path / "ansible.cfg"
     cfg.write_text("[defaults]\ncollections_path = .\n", encoding="utf-8")
     config = _make_config(tmp_path, output, ansible_cfg=cfg)
@@ -140,7 +147,12 @@ def test_galaxy_env_includes_ansible_config(tmp_path: Path, output: Output) -> N
 
 
 def test_galaxy_env_omits_ansible_config_when_unset(tmp_path: Path, output: Output) -> None:
-    """ANSIBLE_CONFIG is omitted when no trusted cfg was selected."""
+    """ANSIBLE_CONFIG is omitted when no trusted cfg was selected.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+    """
     config = _make_config(tmp_path, output, ansible_cfg=None)
     installer = Installer(config=config, output=output)
 
@@ -148,12 +160,18 @@ def test_galaxy_env_omits_ansible_config_when_unset(tmp_path: Path, output: Outp
     assert "ANSIBLE_CONFIG" not in env
 
 
-def test_local_install_preinstalls_deps_and_uses_no_deps(
+def test_local_install_installs_deps_then_uses_no_deps(
     tmp_path: Path,
     output: Output,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Local install installs galaxy.yml deps then the tarball with --no-deps."""
+    """Local install installs galaxy.yml deps then the tarball with --no-deps.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     cfg = tmp_path / "ansible.cfg"
     cfg.write_text("[defaults]\ncollections_path = .\n", encoding="utf-8")
     config = _make_config(tmp_path, output, ansible_cfg=cfg)
@@ -169,7 +187,7 @@ def test_local_install_preinstalls_deps_and_uses_no_deps(
 
     calls: list[dict[str, Any]] = []
 
-    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:  # noqa: ANN401
         calls.append(kwargs)
         command = kwargs["command"]
         if "collection build" in command:
@@ -220,7 +238,13 @@ def test_local_install_without_deps_skips_no_deps(
     output: Output,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Local install without galaxy.yml deps does not use --no-deps."""
+    """Local install without galaxy.yml deps does not use --no-deps.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     config = _make_config(tmp_path, output, ansible_cfg=None)
     collection = _make_local_collection(
         config,
@@ -231,7 +255,7 @@ def test_local_install_without_deps_skips_no_deps(
 
     calls: list[dict[str, Any]] = []
 
-    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:  # noqa: ANN401
         calls.append(kwargs)
         if "collection install" in kwargs["command"]:
             collection.site_pkg_path.mkdir(parents=True, exist_ok=True)
@@ -266,7 +290,14 @@ def test_auth_failure_emits_hint(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Access-token failures emit a hint about AH offline tokens and ANSIBLE_CONFIG."""
+    """Access-token failures emit a hint about AH offline tokens and ANSIBLE_CONFIG.
+
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+        capsys: Pytest capture fixture.
+    """
     cfg = tmp_path / "ansible.cfg"
     cfg.write_text("[defaults]\ncollections_path = .\n", encoding="utf-8")
     config = _make_config(tmp_path, output, ansible_cfg=cfg)
@@ -277,7 +308,7 @@ def test_auth_failure_emits_hint(
     )
     installer = Installer(config=config, output=output)
 
-    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def mock_subprocess_run(**kwargs: Any) -> subprocess.CompletedProcess[str]:  # noqa: ANN401
         command = kwargs["command"]
         if "collection build" in command:
             return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
@@ -308,9 +339,13 @@ def test_cli_assigns_trusted_ansible_cfg(
     output: Output,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cli.run copies acfg_trusted onto Config.ansible_cfg."""
-    from ansible_dev_environment.cli import Cli
+    """Cli.run copies acfg_trusted onto Config.ansible_cfg.
 
+    Args:
+        tmp_path: Temporary directory.
+        output: Output fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "sys.argv",


### PR DESCRIPTION
Pin trusted ansible.cfg into ansible-galaxy subprocesses and pre-install galaxy.yml dependencies into the venv so ade matches ansible-galaxy server/token behavior (AAP-48435).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local collection installations now automatically install dependencies declared in `galaxy.yml`.
  - Trusted Ansible configuration is applied consistently during Galaxy operations.
  - Dependency specifications are converted automatically for installation.

- **Bug Fixes**
  - Improved Automation Hub authentication-failure messages with clearer troubleshooting guidance.
  - Local collection installs avoid reinstalling dependencies unnecessarily.

- **Tests**
  - Added coverage for dependency installation, authentication errors, configuration handling, and local collection workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->